### PR TITLE
simple example of miniKanren rule matching

### DIFF
--- a/pynars/NARS/InferenceEngine/Logic.py
+++ b/pynars/NARS/InferenceEngine/Logic.py
@@ -1,0 +1,51 @@
+from kanren import run, eq, var
+
+rule = '''{<M --> P>, <S --> M>} |- <S --> P>'''
+
+premises, conclusion = rule.split(" |- ")
+
+p1, p2 = premises.strip("{}").split(", ")
+
+p1 = p1.strip("<>").split()
+p2 = p2.strip("<>").split()
+c = conclusion.strip("<>").split()
+
+# print(p1, p2, c) # ['M', '-->', 'P'] ['S', '-->', 'M'] ['S', '-->', 'P']
+
+_vars = {} # mappings of terms to vars
+
+def replace_terms(t: str):
+    if t.isalpha():
+        if not t in _vars:
+            _vars[t] = var()
+        return _vars[t]
+    else:
+        return t
+
+p1 = list(map(replace_terms, p1))
+p2 = list(map(replace_terms, p2))
+c = list(map(replace_terms, c))
+
+# print(p1, p2, c) # [~_1, '-->', ~_2] [~_3, '-->', ~_1] [~_3, '-->', ~_2]
+
+t1, t2 = "bird --> animal", "robin --> bird"
+t1, t2 = t1.split(), t2.split() # ["bird", "-->", "animal"], ["robin", "-->", "bird"]
+
+# apply rule
+
+result = run(1, c, eq(p1, t1), eq(p2, t2))
+# print(res)
+
+if result:
+    print("Positive example:")
+    print(' '.join(result[0])) # robin --> animal
+
+
+t3, t4 = ["bird", "-->", "animal"], ["bird", "-->", "[flying]"]
+
+result = run(1, c, eq(p1, t3), eq(p2, t4))
+
+if not result:
+    print("\nNegative example:")
+    print("Failed to match rule pattern to premises")
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ tqdm<=3.1.4
 typing>=3.7.4.3
 typing_extensions>=4.0.1
 sparse-lut>=1.0.0
+miniKanren>=1.0.3


### PR DESCRIPTION
This is just to show the basics of how to apply miniKanren to rule matching. Not meant to be merged as is.

Hopefully this will make it a bit more clear in terms of how this can be applied to all other rules.

I took one of the rules, deduction, as an example. The string representing the rule is parsed and converted, then variables are substituted for terms and finally miniKanren is used to unify the premises and test statements. If they can be unified, a substitution is performed producing a conclusion. I also added a negative case at the end demonstrating failure to match the rule pattern.

Perhaps we can use this as a starting point and you can help me make this code more pythonic.