### PR TITLE
Fix to issue #26

### DIFF
--- a/pynars/Console.py
+++ b/pynars/Console.py
@@ -80,8 +80,8 @@ def handle_lines(nars: Reasoner, lines: str):
 
     tasks_lines: List[Tuple[List[Task], Task, Task, List[Task], Task, Tuple[Task, Task]]]
     for tasks_line in tasks_lines:
-        tasks_derived, judgement_revised, goal_revised, answers_question, answers_quest, (
-        task_operation_return, task_executed) = tasks_line
+        tasks_derived, judgement_revised, goal_revised, answers_question, answers_quest, \
+        (task_operation_return, task_executed) = tasks_line
         for task in tasks_derived: print_out(PrintType.OUT, task.sentence.repr(), *task.budget)
 
         if judgement_revised is not None: print_out(PrintType.OUT, judgement_revised.sentence.repr(),
@@ -90,8 +90,9 @@ def handle_lines(nars: Reasoner, lines: str):
         if answers_question is not None:
             for answer in answers_question: print_out(PrintType.ANSWER, answer.sentence.repr(), *answer.budget)
         if answers_quest is not None:
-            for answer in answers_quest: print_out(PrintType.ANSWER, answers_quest.sentence.repr(),
-                                                   *answers_quest.budget)
+            for answer in answers_quest:
+                print_out(PrintType.ACHIEVED, answer.sentence.repr(),
+                                                   *answer.budget)
         if task_executed is not None:
             print_out(PrintType.EXE,
                       f'{task_executed.term.repr()} = {str(task_operation_return) if task_operation_return is not None else None}')

--- a/pynars/Console.py
+++ b/pynars/Console.py
@@ -91,8 +91,7 @@ def handle_lines(nars: Reasoner, lines: str):
             for answer in answers_question: print_out(PrintType.ANSWER, answer.sentence.repr(), *answer.budget)
         if answers_quest is not None:
             for answer in answers_quest:
-                print_out(PrintType.ACHIEVED, answer.sentence.repr(),
-                                                   *answer.budget)
+                print_out(PrintType.ACHIEVED, answer.sentence.repr(), *answer.budget)
         if task_executed is not None:
             print_out(PrintType.EXE,
                       f'{task_executed.term.repr()} = {str(task_operation_return) if task_operation_return is not None else None}')

--- a/pynars/Console.py
+++ b/pynars/Console.py
@@ -90,8 +90,7 @@ def handle_lines(nars: Reasoner, lines: str):
         if answers_question is not None:
             for answer in answers_question: print_out(PrintType.ANSWER, answer.sentence.repr(), *answer.budget)
         if answers_quest is not None:
-            for answer in answers_quest:
-                print_out(PrintType.ACHIEVED, answer.sentence.repr(), *answer.budget)
+            for answer in answers_quest: print_out(PrintType.ACHIEVED, answer.sentence.repr(), *answer.budget)
         if task_executed is not None:
             print_out(PrintType.EXE,
                       f'{task_executed.term.repr()} = {str(task_operation_return) if task_operation_return is not None else None}')

--- a/pynars/NARS/DataStructures/_py/Memory.py
+++ b/pynars/NARS/DataStructures/_py/Memory.py
@@ -86,8 +86,7 @@ class Memory:
     def _accept_judgement(self, task: Task, concept: Concept):
         ''''''
         belief_revised = None
-        answers = { Question: [],
-                             Goal: []}
+        answers = { Question: [], Goal: []}
         if Enable.operation: raise  # InternalExperienceBuffer.handleOperationFeedback(task, nal);
         if Enable.anticipation: raise  # ProcessAnticipation.confirmAnticipation(task, concept, nal);
 
@@ -112,7 +111,6 @@ class Memory:
                 # reduce priority by achieving level
                 task.reduce_budget_by_achieving_level(belief)
 
-        answers_goals = []
         if task.budget.is_above_thresh:
             '''final int nnq = concept.questions.size();
             for (int i = 0; i < nnq; i++) {

--- a/pynars/NARS/DataStructures/_py/Memory.py
+++ b/pynars/NARS/DataStructures/_py/Memory.py
@@ -126,7 +126,7 @@ class Memory:
 
             for task_goal in concept.desire_table:
                 _, goal_answer = self._solve_goal(task_goal, concept, None, task)
-                answers[Goal] = [goal_answer]
+                if goal_answer is not None: answers[Goal] = [goal_answer]
 
         return belief_revised, answers
 
@@ -360,15 +360,18 @@ class Memory:
             concept (Concept): The concept corresponding to the task.
         '''
         tasks = []
-        belief = belief or concept.match_belief(task.sentence)
-        if belief is None:
-            return tasks, None
         old_best = task.best_solution
+
+        belief = belief or concept.match_belief(task.sentence)
+        if belief is None or belief == old_best:
+            return tasks, None
+
         if old_best is not None:
             quality_new = calculate_solution_quality(task.sentence, belief.sentence, True)
             quality_old = calculate_solution_quality(task.sentence, old_best.sentence, True)
             if (quality_new <= quality_old):
                 return tasks, belief
+
         task.best_solution = belief
         tasks.append(belief) # the task as the new best solution should be added into the internal buffer, so that it would be paid attention
         budget = Budget_evaluate_goal_solution(task.sentence, belief.sentence, task.budget, (task_link.budget if task_link is not None else None))

--- a/pynars/NARS/DataStructures/_py/Memory.py
+++ b/pynars/NARS/DataStructures/_py/Memory.py
@@ -38,8 +38,7 @@ class Memory:
         if task.is_judgement:
             # revised the belief if there has been one, and try to solve question if there has been a corresponding one.
             task_revised, answers = self._accept_judgement(task, concept)
-            answers_question = answers[Question]
-            answer_quest = answers[Goal]
+            answers_question, answer_quest = answers[Question], answers[Goal]
         elif task.is_goal:
             task_revised, belief_selected, (task_operation_return, task_executed), tasks_derived = self._accept_goal(task, concept)
             # TODO, ugly!

--- a/pynars/NARS/DataStructures/_py/Memory.py
+++ b/pynars/NARS/DataStructures/_py/Memory.py
@@ -85,7 +85,7 @@ class Memory:
     def _accept_judgement(self, task: Task, concept: Concept):
         ''''''
         belief_revised = None
-        answers = { Question: [], Goal: []}
+        answers = { Question: [], Goal: [] }
         if Enable.operation: raise  # InternalExperienceBuffer.handleOperationFeedback(task, nal);
         if Enable.anticipation: raise  # ProcessAnticipation.confirmAnticipation(task, concept, nal);
 

--- a/pynars/NARS/DataStructures/_py/Memory.py
+++ b/pynars/NARS/DataStructures/_py/Memory.py
@@ -37,7 +37,9 @@ class Memory:
         task_revised, goal_derived, answers_question, answer_quest = None, None, None, None
         if task.is_judgement:
             # revised the belief if there has been one, and try to solve question if there has been a corresponding one.
-            task_revised, answers_question = self._accept_judgement(task, concept)
+            task_revised, answers = self._accept_judgement(task, concept)
+            answers_question = answers[Question]
+            answer_quest = answers[Goal]
         elif task.is_goal:
             task_revised, belief_selected, (task_operation_return, task_executed), tasks_derived = self._accept_goal(task, concept)
             # TODO, ugly!
@@ -84,7 +86,8 @@ class Memory:
     def _accept_judgement(self, task: Task, concept: Concept):
         ''''''
         belief_revised = None
-        answers = None
+        answers = { Question: [],
+                             Goal: []}
         if Enable.operation: raise  # InternalExperienceBuffer.handleOperationFeedback(task, nal);
         if Enable.anticipation: raise  # ProcessAnticipation.confirmAnticipation(task, concept, nal);
 
@@ -109,6 +112,7 @@ class Memory:
                 # reduce priority by achieving level
                 task.reduce_budget_by_achieving_level(belief)
 
+        answers_goals = []
         if task.budget.is_above_thresh:
             '''final int nnq = concept.questions.size();
             for (int i = 0; i < nnq; i++) {
@@ -121,11 +125,11 @@ class Memory:
             concept.add_belief(task)
 
             # try to solve questions
-            answers = self._solve_judgement(task, concept)
+            answers[Question] = self._solve_judgement(task, concept)
 
             for task_goal in concept.desire_table:
-                answers_goal, _ = self._solve_goal(task_goal, concept, None, task)
-                answers.extend(answers_goal)
+                _, goal_answer = self._solve_goal(task_goal, concept, None, task)
+                answers[Goal] = [goal_answer]
 
         return belief_revised, answers
 

--- a/pynars/utils/Print.py
+++ b/pynars/utils/Print.py
@@ -7,6 +7,7 @@ class PrintType(Enum):
     OUT = f'{fg.yellow}OUT   :{fg.rs}'
     ERROR = f'{fg.red}ERROR :{fg.rs}'
     ANSWER = f'{fg.green}ANSWER:{fg.rs}'
+    ACHIEVED = f'{fg.green}ACHIEVED:{fg.rs}'
     EXE = f'{fg.green}EXE   :{fg.rs}'
     INFO = f'{fg.blue}INFO  :{fg.rs}'
     COMMENT = F'{fg.grey}COMMENT:{fg.rs}'


### PR DESCRIPTION
_**Desired functionality:**_ When inputting a judgment to NARS, if there is a corresponding Goal or Question already stored in the concept, we should print to the user that the input judgment has completed the Goal/Question.

_**Previously,**_ when a judgment is processed, the program return answers in an list (i.e., a list of judgments). This list however did not delineate between answers to goals vs. questions; furthermore, the goal itself was extraneously placed into the list of answers. Then, the contents of the list were being printed as though they were answers to questions.

_**Now,**_ we delineate between answers to questions vs. answers to goals using a dictionary. Also, the goal is no longer extraneously added to the list of answers. With this delineation, we can choose different ways to print answers to goals vs. questions. Now, answers to goals are printed as "Achieved:"

New behavior:

![image](https://github.com/bowen-xu/PyNARS/assets/15344554/4ea2a127-619c-402e-84ca-7ec207f1ea2b)

