### PR TITLE
use truth in hash function of Sentence

### DIFF
--- a/pynars/Narsese/_py/Sentence.py
+++ b/pynars/Narsese/_py/Sentence.py
@@ -114,7 +114,7 @@ class Sentence:
         return sentence
 
     def __hash__(self) -> int:
-        return hash((self.term, self.punct))
+        return hash((self.term, self.punct, self.truth))
 
     def __str__(self) -> str:
         return self.word

--- a/pynars/Narsese/_py/Truth.py
+++ b/pynars/Narsese/_py/Truth.py
@@ -21,6 +21,9 @@ class Truth:
         '''return (f, c, k)'''
         return iter((self.f, self.c, self.k))
 
+    def __hash__(self) -> int:
+        return hash((self.f, self.c, self.k))
+
     def __str__(self) -> str:
         return f'%{self.f:.3f};{self.c:.3f}%'
     


### PR DESCRIPTION
@bowen-xu I looked at the code and it seems the core of the issue is the hash of Task not taking truth value into account. This simple change achieves what you described in the issue but I wonder if it could have some unintended consequences? Can you think of the situation when elsewhere in the code we would want two sentences to compare same regardless of their truth values? Then we could try a different fix.