### PR TITLE
Port the "volume" mechanism from OpenNARS

### DIFF
--- a/pynars/ConsolePlus.py
+++ b/pynars/ConsolePlus.py
@@ -221,6 +221,19 @@ def toggle_silent() -> None:
         }.''')
 
 
+@cmd_register(('volume'), (int, 100))
+def volume(vol:int) -> None:
+    '''Format: volume [volume:int 0~100]
+    Set the Output Volume of the console to control its output (same as OpenNARS)'''
+    if 0 <= vol <= 100:
+        current_NARS_interface.silence_value = 1 - vol * 0.01 # same as `(100-vol)/100`
+        current_NARS_interface.print_output(
+            type=PrintType.INFO, content=f'''Volume is set to "*volume={vol}".''')
+    else:
+        current_NARS_interface.print_output(
+            type=PrintType.INFO, content=f'''Volume {vol} is out of range 0~100!''')
+
+
 @cmd_register(('toggle-color', 'color'))
 def toggle_color() -> None:
     '''Toggle the color display of cmds (for terminals that do not support custom foreground/background colors)'''

--- a/pynars/ConsolePlus.py
+++ b/pynars/ConsolePlus.py
@@ -226,7 +226,7 @@ def volume(vol:int) -> None:
     '''Format: volume [volume:int 0~100]
     Set the Output Volume of the console to control its output (same as OpenNARS)'''
     if 0 <= vol <= 100:
-        current_NARS_interface.silence_value = 1 - vol * 0.01 # same as `(100-vol)/100`
+        current_NARS_interface.volume_threshold = 1 - vol * 0.01 # same as `(100-vol)/100`
         current_NARS_interface.print_output(
             type=PrintType.INFO, content=f'''Volume is set to "*volume={vol}".''')
     else:

--- a/pynars/Narsese/_py/Budget.py
+++ b/pynars/Narsese/_py/Budget.py
@@ -52,3 +52,17 @@ class Budget:
             ```
         '''
         return Budget(self.priority/sqrt((n if n > 0 else 1)), self.durability, self.quality)
+    
+    @property
+    def total(self) -> float:
+        '''
+        To summarize a BudgetValue into a single number in [0, 1]
+        It's used for introduce the 'volume' by comparing with the number of silence level
+        Ref. OpenNARS 3.1.2 BudgetValue.java line 194~200:
+            ```
+            public float totalBudget() {
+                return UtilityFunctions.aveGeo(priority.getValue(), durability.getValue(), quality.getValue());
+            }
+            ```
+        '''
+        return (self.priority * self.durability * self.quality)**(1/3)

--- a/pynars/Narsese/_py/Budget.py
+++ b/pynars/Narsese/_py/Budget.py
@@ -52,17 +52,3 @@ class Budget:
             ```
         '''
         return Budget(self.priority/sqrt((n if n > 0 else 1)), self.durability, self.quality)
-    
-    @property
-    def total(self) -> float:
-        '''
-        To summarize a BudgetValue into a single number in [0, 1]
-        It's used for introduce the 'volume' by comparing with the number of silence level
-        Ref. OpenNARS 3.1.2 BudgetValue.java line 194~200:
-            ```
-            public float totalBudget() {
-                return UtilityFunctions.aveGeo(priority.getValue(), durability.getValue(), quality.getValue());
-            }
-            ```
-        '''
-        return (self.priority * self.durability * self.quality)**(1/3)


### PR DESCRIPTION
# Introduction

A simple "volume" mechanism, ported from OpenNARS, allows the use of cmd `volume` to set values as OpenNARS does and thus limit the production of `OUT` type output.

# Preview

![image](https://github.com/bowen-xu/PyNARS/assets/61109168/1fc8bd31-3d0f-4133-9e40-4a65a3f0422a)
