### PR TITLE
add maximum_evidental_base_length to Config

### DIFF
--- a/pynars/Config.py
+++ b/pynars/Config.py
@@ -79,6 +79,8 @@ class Config:
     novelty_horizon = 100000
     term_link_record_length = 10
 
+    maximum_evidental_base_length = 20000
+
     @classmethod
     def check(cls):
         '''Check if each parameter is valid'''

--- a/pynars/Narsese/_py/Evidence.py
+++ b/pynars/Narsese/_py/Evidence.py
@@ -44,14 +44,24 @@ class Base:
 
         # TODO: Ref: OpenNARS 3.1.0 Stamp.java line 178~187.
         # TODO: Optimize this loop with cython.
-        # while (j < baseLength) {
-        #     if(i2 < secondLength) {
-        #         evidentialBase[j++] = secondBase[i2++];
-        #     }
-        #     if(i1 < firstLength) {
-        #         evidentialBase[j++] = firstBase[i1++];
-        #     }
-        # }
+        b1 = len(base1)
+        b2 = len(base2)
+        base_length = min(b1 + b2, Config.maximum_evidental_base_length)
+        evidential_base: Set[int] = OrderedSet()
+
+        i1 = i2 = j = 0
+
+        while j < base_length:
+            if i2 < b2:
+                evidential_base.add(base2[i2])
+                j += 1
+                i2 += 1
+            if i1 < b1:
+                evidential_base.add(base1[i1])
+                j += 1
+                i1 += 1
+
+        return evidential_base
 
     def add(self, id_evidence: int):
         self._hash = None
@@ -60,12 +70,7 @@ class Base:
     
     def extend(self, base: Union[Type['Base'] , None]):
         self._hash = None
-        self._set = self._set.union(base._set)
-        # set upper limit on the size of evidential base
-        limit = len(self._set) - Config.maximum_evidental_base_length
-        if limit > 0:
-            # discard old evidence
-            self._set = self._set[limit:]
+        self._set = self.interleave(self._set, base)
         return self
 
     def is_overlaped(self, base: Union[Type['Base'], None]) -> bool:

--- a/pynars/Narsese/_py/Evidence.py
+++ b/pynars/Narsese/_py/Evidence.py
@@ -60,7 +60,12 @@ class Base:
     
     def extend(self, base: Union[Type['Base'] , None]):
         self._hash = None
-        self._set = self._set.union(base._set)[:Config.maximum_evidental_base_length]
+        self._set = self._set.union(base._set)
+        # set upper limit on the size of evidential base
+        limit = len(self._set) - Config.maximum_evidental_base_length
+        if limit > 0:
+            # discard old evidence
+            self._set = self._set[limit:]
         return self
 
     def is_overlaped(self, base: Union[Type['Base'], None]) -> bool:

--- a/pynars/Narsese/_py/Evidence.py
+++ b/pynars/Narsese/_py/Evidence.py
@@ -60,7 +60,7 @@ class Base:
     
     def extend(self, base: Union[Type['Base'] , None]):
         self._hash = None
-        self._set = self._set.union(base._set)
+        self._set = self._set.union(base._set)[:Config.maximum_evidental_base_length]
         return self
 
     def is_overlaped(self, base: Union[Type['Base'], None]) -> bool:


### PR DESCRIPTION
@bowen-xu I looked at the description of #6 and at OpenNARS code you reference. From my understanding because you use an ordered set in PyNARS, the extend method which takes a union of both bases will already ensure the ordering and interleaving, and all that was missing is the upper limit. I added the parameter with the same value as in OpenNARS. I believe this accomplished what was intended.

Alternatively, if we want to bring the implementations closer, we would have to reimplement the evidential base using lists instead of ordered sets but I'm not sure this is necessary.