### PR TITLE
TESTS: modify tests to call reasoner directly

### DIFF
--- a/Tests/test_NAL/test_NAL1.py
+++ b/Tests/test_NAL/test_NAL1.py
@@ -34,9 +34,10 @@ class TEST_NAL1(unittest.TestCase):
         'Bird is very likely to be a type of swimmer.
         ''outputMustContain('<bird --> swimmer>. %0.87;0.91%')
         '''
-        tasks_derived = memory_accept_revision(
+        tasks_derived = process_two_premises(
             '<bird --> swimmer>. %1.00;0.90%',
-            '<bird --> swimmer>. %0.10;0.60%'
+            '<bird --> swimmer>. %0.10;0.60%',
+            2
         )
         self.assertTrue(
             output_contains(tasks_derived, '<bird --> swimmer>. %0.87;0.91%')
@@ -60,11 +61,11 @@ class TEST_NAL1(unittest.TestCase):
         'Robin is a type of animal.
         ''outputMustContain('<robin --> animal>. %1.00;0.81%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<bird --> animal>. %1.00;0.90%', 
             '<robin --> bird>. %1.00;0.90%', 
-            'bird.')
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+            10
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<robin --> animal>. %1.00;0.81%')
         )
@@ -90,11 +91,11 @@ class TEST_NAL1(unittest.TestCase):
         'I guess chess is a type of sport.
         ''outputMustContain('<chess --> sport>. %0.90;0.45%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<sport --> competition>. %1.00;0.90%', 
             '<chess --> competition>. %0.90;0.90%', 
-            'competition.')
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+            5
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<sport --> chess>. %1.00;0.42%')
         )
@@ -123,11 +124,11 @@ class TEST_NAL1(unittest.TestCase):
         'I guess swimmer is a type of bird.
         ''outputMustContain('<swimmer --> bird>. %1.00;0.42%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<swan --> swimmer>. %0.90;0.90%', 
             '<swan --> bird>.  %1.00;0.90%', 
-            'swan.')
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+            5
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<bird --> swimmer>. %0.90;0.45%')
         )
@@ -153,11 +154,11 @@ class TEST_NAL1(unittest.TestCase):
         'I guess animal is a type of robin. 
         ''outputMustContain('<animal --> robin>. %1.00;0.45%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<robin --> bird>. %1.00;0.90%', 
             '<bird --> animal>. %1.00;0.90%', 
-            'bird.')
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+            5
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<animal --> robin>. %1.00;0.45%')
         )
@@ -180,12 +181,11 @@ class TEST_NAL1(unittest.TestCase):
         'I guess swimmer is a type of bird.
         ''outputMustContain('<swimmer --> bird>. %1.00;0.47%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<bird --> swimmer>. %1.00;0.90%', 
             '<swimmer --> bird>?', 
-            'bird.',
-            True)
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+            6
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<swimmer --> bird>. %1.00;0.47%')
         )
@@ -208,16 +208,15 @@ class TEST_NAL1(unittest.TestCase):
         ' Bird is a type of swimmer.
         ''outputMustContain('<bird --> swimmer>. %1.00;0.90%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<bird --> swimmer>. %1.00;0.90%', 
             '<bird --> swimmer>? ', 
-            'bird.', 
-            True)
-        _, _, answers_question, *_ = result2
+            2 
+        )
         # self.assertIsNone(rules)
         # tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
         self.assertTrue(
-            output_contains(answers_question, '<bird --> swimmer>. %1.00;0.90%')
+            output_contains(tasks_derived, '<bird --> swimmer>. %1.00;0.90%')
         )
         
         pass    
@@ -237,15 +236,14 @@ class TEST_NAL1(unittest.TestCase):
         ' Bird is a type of swimmer.
         ''outputMustContain('<bird --> swimmer>. %1.00;0.80%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<bird --> swimmer>. %1.00;0.80%', 
             '<?x --> swimmer>?', 
-            'swimmer.', 
-            True)
-        _, _, answers_quest, *_ = result2
+            5
+        )
         # tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
         self.assertTrue(
-            output_contains(answers_quest, '<bird --> swimmer>. %1.00;0.80%')
+            output_contains(tasks_derived, '<bird --> swimmer>. %1.00;0.80%')
         )
         
         pass    
@@ -267,15 +265,14 @@ class TEST_NAL1(unittest.TestCase):
         ' Bird is a type of swimmer.
         ''outputMustContain('(&&, <bird --> swimmer>, <bird --> flyer>). %1.00;0.81%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<bird --> swimmer>. %1.00;0.80%', 
             '<?x --> swimmer>?', 
-            'swimmer.', 
-            True)
-        _, _, answers_quest, *_ = result2
+            5
+        )
         # tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
         self.assertTrue(
-            output_contains(answers_quest, '<bird --> swimmer>. %1.00;0.80%')
+            output_contains(tasks_derived, '<bird --> swimmer>. %1.00;0.80%')
         )
         
         pass    
@@ -299,13 +296,11 @@ class TEST_NAL1(unittest.TestCase):
         ' What is the type of bird?
         ''outputMustContain('<bird --> ?1>?')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<bird --> swimmer>. %1.00;0.80%', 
             '<?x --> swimmer>?', 
-            'swimmer.', 
-            True)
-        task.sentence.repr
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+            6
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<?1 --> bird>?')
         )

--- a/Tests/test_NAL/test_NAL2.py
+++ b/Tests/test_NAL/test_NAL2.py
@@ -25,9 +25,10 @@ class TEST_NAL2(unittest.TestCase):
         ''outputMustContain('<robin <-> swan>. %0.87;0.91%')
         '''
 
-        tasks_derived = memory_accept_revision(
+        tasks_derived = process_two_premises(
             '<robin <-> swan>. %1.00;0.90%',
-            '<robin <-> swan>. %0.10;0.60%'
+            '<robin <-> swan>. %0.10;0.60%',
+            2
         )
         self.assertTrue(
             output_contains(tasks_derived, '<robin <-> swan>. %0.87;0.91%')
@@ -50,12 +51,11 @@ class TEST_NAL2(unittest.TestCase):
         ''outputMustContain('<bird <-> swimmer>. %0.90;0.45%')
         '''
 
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<swan --> swimmer>. %0.90;0.90%', 
             '<swan --> bird>. %1.00;0.90%', 
-            'swan.', 
-            True)
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+            3
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<bird <-> swimmer>. %0.90;0.45%')
         )
@@ -78,12 +78,11 @@ class TEST_NAL2(unittest.TestCase):
         ''outputMustContain('<{?1} --> bird>?')
         '''
 
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<bird --> swimmer>. %1.00;0.90%', 
             '<{?1} --> swimmer>?', 
-            'swimmer.', 
-            True)
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+            6 
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<{?1} --> bird>?')
         )
@@ -107,12 +106,11 @@ class TEST_NAL2(unittest.TestCase):
         ''outputMustContain('<chess <-> sport>. %0.90;0.45%')
         '''
 
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<sport --> competition>. %1.00;0.90%', 
             '<chess --> competition>. %0.90;0.90% ', 
-            'competition.', 
-            True)
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+            5 
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<chess <-> sport>. %0.90;0.45%')
         )
@@ -135,11 +133,11 @@ class TEST_NAL2(unittest.TestCase):
         ''outputMustContain('<gull --> swimmer>. %1.00;0.81%')
         '''
 
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<swan --> swimmer>. %1.00;0.90%', 
             '<gull <-> swan>. %1.00;0.90%', 
-            'swan.', index_task=(0,), index_belief=(1,))
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+            5
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<gull --> swimmer>. %1.00;0.81%')
         )
@@ -161,12 +159,11 @@ class TEST_NAL2(unittest.TestCase):
         ''outputMustContain('<swan --> swimmer>. %1.00;0.81%')
         '''
 
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<gull --> swimmer>. %1.00;0.90%', 
             '<gull <-> swan>. %1.00;0.90%', 
-            'gull.',
-            True)
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+            5
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<swan --> swimmer>. %1.00;0.81%')
         )
@@ -188,12 +185,11 @@ class TEST_NAL2(unittest.TestCase):
         ''outputMustContain('<gull <-> robin>. %1.00;0.81%')
         '''
 
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<robin <-> swan>. %1.00;0.90%', 
             '<gull <-> swan>. %1.00;0.90%', 
-            'swan.',
-            True)
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+            5
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<gull <-> robin>. %1.00;0.81%')
         )
@@ -216,11 +212,11 @@ class TEST_NAL2(unittest.TestCase):
         ''outputMustContain('<bird <-> swan>. %0.10;0.81%')
         '''
 
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<swan --> bird>. %1.00;0.90%', 
             '<bird --> swan>. %0.10;0.90%', 
-            'bird.', index_task=(1,), index_belief=(0,))
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+            2
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<bird <-> swan>. %0.10;0.81%')
         )
@@ -243,12 +239,11 @@ class TEST_NAL2(unittest.TestCase):
         ''outputMustContain('<[smart] --> [bright]>. %0.90;0.66%')
         '''
 
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<bright <-> smart>. %0.90;0.90%', 
             '<[smart] --> [bright]>?', 
-            'bright.',
-            True)
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+            10
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<[bright] <-> [smart]>. %0.90;0.90%')
         )
@@ -273,12 +268,11 @@ class TEST_NAL2(unittest.TestCase):
         ''outputMustContain('<{Birdie} <-> {Tweety}>. %0.90;0.73%')
         '''
 
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<Birdie <-> Tweety>. %0.90;0.90%', 
             '<{Birdie} <-> {Tweety}>?', 
-            'Birdie.',
-            True)
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+            10
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<{Birdie} <-> {Tweety}>. %0.90;0.73%')
         )
@@ -300,12 +294,11 @@ class TEST_NAL2(unittest.TestCase):
         ''outputMustContain('<bird --> swan>. %0.10;0.73%')
         '''
 
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<swan --> bird>. %1.00;0.90%', 
             '<bird <-> swan>. %0.10;0.90%', 
-            'bird.',
-            True)
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+            10
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<bird --> swan>. %0.10;0.73%')
         )
@@ -329,12 +322,11 @@ class TEST_NAL2(unittest.TestCase):
         ''outputMustContain('<bird <-> swan>. %0.90;0.47%')
         '''
 
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<swan --> bird>. %0.90;0.90%', 
             '<bird <-> swan>?', 
-            'bird.',
-            True)
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+            10
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<bird <-> swan>. %0.90;0.47%')
         )
@@ -357,12 +349,11 @@ class TEST_NAL2(unittest.TestCase):
         ''outputMustContain('<swan --> bird>. %0.90;0.81%')
         '''
 
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<bird <-> swan>. %0.90;0.90%', 
             '<swan --> bird>?', 
-            'bird.',
-            True)
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+            10
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<swan --> bird>. %0.90;0.81%')
         )
@@ -381,8 +372,11 @@ class TEST_NAL2(unittest.TestCase):
         ''outputMustContain('<{Tweety} --> bird>. %1.00;0.90%')
         '//expect.outEmpty
         '''
-        task = Narsese.parse('<Tweety {-- bird>. %1.00;0.90%')
-        tasks_derived = [task]
+        tasks_derived = process_two_premises(
+            '<Tweety {-- bird>. %1.00;0.90%',
+            None,
+            1
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<{Tweety} --> bird>. %1.00;0.90%')
         )
@@ -400,8 +394,11 @@ class TEST_NAL2(unittest.TestCase):
 
         ''outputMustContain('<raven --> [black]>. %1.00;0.90%')
         '''
-        task = Narsese.parse('<raven --] black>. %1.00;0.90%')
-        tasks_derived = [task]
+        tasks_derived = process_two_premises(
+            '<raven --] black>. %1.00;0.90%',
+            None,
+            1
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<raven --> [black]>. %1.00;0.90%')
         )
@@ -419,8 +416,11 @@ class TEST_NAL2(unittest.TestCase):
 
         ''outputMustContain('<{Tweety} --> [yellow]>. %1.00;0.90%')
         '''
-        task = Narsese.parse('<Tweety {-] yellow>. %1.00;0.90%')
-        tasks_derived = [task]
+        tasks_derived = process_two_premises(
+            '<Tweety {-] yellow>. %1.00;0.90%',
+            None,
+            1
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<{Tweety} --> [yellow]>. %1.00;0.90%')
         )
@@ -438,8 +438,11 @@ class TEST_NAL2(unittest.TestCase):
         'Birdie is similar to Tweety. 
         ''outputMustContain('<{Birdie} <-> {Tweety}>. %1.00;0.90%')
         '''
-        task = Narsese.parse('<{Tweety} --> {Birdie}>. %1.00;0.90%')
-        tasks_derived = [task]
+        tasks_derived = process_two_premises(
+            '<{Tweety} --> {Birdie}>. %1.00;0.90%',
+            None,
+            3
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<{Birdie} <-> {Tweety}>. %1.00;0.90%')
         )
@@ -458,8 +461,11 @@ class TEST_NAL2(unittest.TestCase):
         'Bright thing is similar to smart thing. 
         ''outputMustContain('<[bright] <-> [smart]>. %1.00;0.90%')
         '''
-        task = Narsese.parse('<[smart] --> [bright]>. %1.00;0.90%')
-        tasks_derived = [task]
+        tasks_derived = process_two_premises(
+            '<[smart] --> [bright]>. %1.00;0.90%',
+            None,
+            1
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<[bright] <-> [smart]>. %1.00;0.90%')
         )
@@ -481,8 +487,11 @@ class TEST_NAL2(unittest.TestCase):
         'Tweety is Birdie. 
         ''outputMustContain('<{Tweety} --> {Birdie}>. %1.00;0.90%')
         '''
-        task = Narsese.parse('<{Birdie} <-> {Tweety}>. %1.00;0.90%')
-        tasks_derived = [task]
+        tasks_derived = process_two_premises(
+            '<{Birdie} <-> {Tweety}>. %1.00;0.90%',
+            None,
+            1
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<Birdie <-> Tweety>. %1.00;0.90%')
         )
@@ -507,8 +516,11 @@ class TEST_NAL2(unittest.TestCase):
         'Bright thing is a type of smart thing. 
         ''outputMustContain('<[bright] --> [smart]>. %1.00;0.90%')
         '''
-        task = Narsese.parse('<[bright] <-> [smart]>. %1.00;0.90%')
-        tasks_derived = [task]
+        tasks_derived = process_two_premises(
+            '<[bright] <-> [smart]>. %1.00;0.90%',
+            None,
+            1
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<bright <-> smart>. %1.00;0.90%')
         )

--- a/Tests/test_NAL/test_NAL3.py
+++ b/Tests/test_NAL/test_NAL3.py
@@ -40,11 +40,11 @@ class TEST_NAL3(unittest.TestCase):
         'Swan is a type of swimming bird. 
         ''outputMustContain('<swan --> (&,bird,swimmer)>. %0.72;0.81%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<swan --> swimmer>. %0.90;0.90%', 
             '<swan --> bird>. %0.80;0.90%', 
-            'swan.')
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules]
+            16
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<swan --> (&,bird,swimmer)>. %0.72;0.81%')
         )
@@ -66,11 +66,11 @@ class TEST_NAL3(unittest.TestCase):
         'Swan is a type of bird or a type of swimmer. 
         ''outputMustContain('<swan --> (|,bird,swimmer)>. %0.98;0.81%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<swan --> swimmer>. %0.90;0.90%', 
             '<swan --> bird>. %0.80;0.90%', 
-            'swan.')
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+            16
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<swan --> (|,bird,swimmer)>. %0.98;0.81%')
         )        
@@ -92,11 +92,11 @@ class TEST_NAL3(unittest.TestCase):
         'If something is either chess or sport, then it is a competition.
         ''outputMustContain('<(|,chess,sport) --> competition>. %0.72;0.81%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<sport --> competition>. %0.90;0.90%', 
             '<chess --> competition>. %0.80;0.90%', 
-            'competition.')
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+            16
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<(|,chess,sport) --> competition>. %0.72;0.81%')
         )        
@@ -118,11 +118,11 @@ class TEST_NAL3(unittest.TestCase):
         'If something is both chess and sport, then it is a competition.
         ''outputMustContain('<(&,chess,sport) --> competition>. %0.98;0.81%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<sport --> competition>. %0.90;0.90%', 
             '<chess --> competition>. %0.80;0.90%', 
-            'competition.')
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+            16
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<(&,chess,sport) --> competition>. %0.98;0.81%')
         )        
@@ -145,21 +145,21 @@ class TEST_NAL3(unittest.TestCase):
 
         ''outputMustContain('<robin --> bird>. %1.00;0.81%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<robin --> (|,bird,swimmer)>. %1.00;0.90%', 
             '<robin --> swimmer>. %0.00;0.90%', 
-            'robin.')
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+            32
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<robin --> bird>. %1.00;0.81%')
         )        
 
 
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<robin --> swimmer>. %0.00;0.90%', 
             '<robin --> (|,bird,swimmer)>. %1.00;0.90%', 
-            'robin.')
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+            32
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<robin --> bird>. %1.00;0.81%')
         )        
@@ -181,20 +181,20 @@ class TEST_NAL3(unittest.TestCase):
         'Robin is not a type of mammal.
         ''outputMustContain('<robin --> mammal>. %0.00;0.81%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<robin --> swimmer>. %0.00;0.90%', 
             '<robin --> (-,mammal,swimmer)>. %0.00;0.90%', 
-            'robin.')
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+            32
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<robin --> mammal>. %0.00;0.81%')
         )
 
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<robin --> (-,mammal,swimmer)>. %0.00;0.90%', 
             '<robin --> swimmer>. %0.00;0.90%', 
-            'robin.')
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+            32
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<robin --> mammal>. %0.00;0.81%')
         )       
@@ -220,11 +220,11 @@ class TEST_NAL3(unittest.TestCase):
         'PlanetX is probably Pluto. 
         ''outputMustContain('<planetX --> {Pluto}>. %0.63;0.81%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<planetX --> {Mars,Pluto,Venus}>. %0.90;0.90%', 
             '<planetX --> {Pluto,Saturn}>. %0.70;0.90%', 
-            'planetX.')
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+            32
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<planetX --> {Mars,Pluto,Saturn,Venus}>. %0.97;0.81%')
         )
@@ -253,11 +253,11 @@ class TEST_NAL3(unittest.TestCase):
         'PlanetX is either Mars or Venus.
         ''outputMustContain('<planetX --> {Mars,Venus}>. %0.81;0.81%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<planetX --> {Mars,Pluto,Venus}>. %0.90;0.90%', 
             '<planetX --> {Pluto,Saturn}>. %0.10;0.90%', 
-            'planetX.')
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+            32
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<planetX --> {Mars,Pluto,Saturn,Venus}>. %0.91;0.81%')
         )
@@ -283,24 +283,14 @@ class TEST_NAL3(unittest.TestCase):
         'A swimming bird is probably a type of swimming animal.
         ''outputMustContain('<(&,bird,swimmer) --> (&,animal,swimmer)>. %0.90;0.73%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
-            '<bird --> animal>. %0.90;0.90% ', 
-            '(&,bird,swimmer).', 
-            'bird.', is_belief_term=True)
-        tasks_derived = [rule(task, belief.term, task_link, term_link) for rule in rules] 
+        tasks_derived = process_two_premises(
+            '<bird --> animal>. %0.90;0.90%', 
+            '<(&,bird,swimmer) --> (&,animal,swimmer)>?', 
+            32
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<(&,bird,swimmer) --> (&,animal,swimmer)>. %0.90;0.73%')
         )
-
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
-            '<bird --> animal>. %0.90;0.90% ', 
-            '(&,animal,swimmer).', 
-            'animal.', is_belief_term=True)
-        tasks_derived = [rule(task, belief.term, task_link, term_link) for rule in rules] 
-        self.assertTrue(
-            output_contains(tasks_derived, '<(&,bird,swimmer) --> (&,animal,swimmer)>. %0.90;0.73%')
-        )
-        
         pass
 
 
@@ -319,24 +309,14 @@ class TEST_NAL3(unittest.TestCase):
         'A nonanimal swimmer is probably a type of nonbird swimmer.
         ''outputMustContain('<(-,swimmer,animal) --> (-,swimmer,bird)>. %0.90;0.73%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<bird --> animal>. %0.90;0.90%', 
-            '(-,swimmer,animal).', 
-            'animal.', is_belief_term=True)
-        tasks_derived = [rule(task, belief.term, task_link, term_link) for rule in rules] 
+            '<(-,swimmer,animal) --> (-,swimmer,bird)>?', 
+            32
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<(-,swimmer,animal) --> (-,swimmer,bird)>. %0.90;0.73%')
         )
-
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
-            '<bird --> animal>. %0.90;0.90%', 
-            '(-,swimmer,bird).', 
-            'bird.', is_belief_term=True)
-        tasks_derived = [rule(task, belief.term, task_link, term_link) for rule in rules] 
-        self.assertTrue(
-            output_contains(tasks_derived, '<(-,swimmer,animal) --> (-,swimmer,bird)>. %0.90;0.73%')
-        )
-        
         pass
 
     
@@ -355,11 +335,10 @@ class TEST_NAL3(unittest.TestCase):
         'A swan is probably a type of bird or swimmer. 
         ''outputMustContain('<swan --> (|,bird,swimmer)>. %0.90;0.73%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<swan --> bird>. %0.90;0.90%', 
-            '(|,bird, swimmer).', 
-            'bird.', is_belief_term=True)
-        tasks_derived = [rule(task, belief.term, task_link, term_link) for rule in rules] 
+            '<swan --> (|,bird,swimmer)>?', 
+            32)
         self.assertTrue(
             output_contains(tasks_derived, '<swan --> (|,bird,swimmer)>. %0.90;0.73%')
         )
@@ -382,11 +361,11 @@ class TEST_NAL3(unittest.TestCase):
         'Swimming swan is a type of bird.
         ''outputMustContain('<(&,swan,swimmer) --> bird>. %0.90;0.73%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<swan --> bird>. %0.90;0.90%', 
-            '(&,swan,swimmer).', 
-            'swan.', is_belief_term=True)
-        tasks_derived = [rule(task, belief.term, task_link, term_link) for rule in rules] 
+            '<(&,swan,swimmer) --> bird>?', 
+            32
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<(&,swan,swimmer) --> bird>. %0.90;0.73%')
         )
@@ -409,11 +388,11 @@ class TEST_NAL3(unittest.TestCase):
         'A swan is not a type of nonbird swimmer.
         ''outputMustContain('<swan --> (-,swimmer,bird)>. %0.10;0.73%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<swan --> bird>. %0.90;0.90%', 
-            '(-,swimmer,bird).', 
-            'bird.', is_belief_term=True)
-        tasks_derived = [rule(task, belief.term, task_link, term_link) for rule in rules] 
+            '<swan --> (-,swimmer,bird)>?', 
+            32
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<swan --> (-,swimmer,bird)>. %0.10;0.73%')
         )
@@ -433,11 +412,11 @@ class TEST_NAL3(unittest.TestCase):
         'Robin is a type of bird. 
         ''outputMustContain('<robin --> bird>. %0.90;0.73%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<robin --> (&,bird,swimmer)>. %0.90;0.90%', 
-            'bird.', 
-            '(&,bird,swimmer).', is_belief_term=True)
-        tasks_derived = [rule(task, belief.term, task_link, term_link) for rule in rules] 
+            None,
+            32
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<robin --> bird>. %0.90;0.73%')
         )
@@ -457,25 +436,14 @@ class TEST_NAL3(unittest.TestCase):
         'Robin is a type of bird. 
         ''outputMustContain('<robin --> bird>. %0.90;0.73%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<robin --> (-,bird,swimmer)>. %0.90;0.90% ', 
-            'bird.', 
-            '(-,bird,swimmer).', is_belief_term=True)
-        tasks_derived = [rule(task, belief.term, task_link, term_link) for rule in rules] 
+            None,
+            32
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<robin --> bird>. %0.90;0.73%')
         )
-
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
-            '<robin --> (-,bird,swimmer)>. %0.90;0.90% ', 
-            'swimmer.', 
-            '(-,bird,swimmer).', is_belief_term=True)
-        if rules is not None:
-            tasks_derived = [rule(task, belief.term, task_link, term_link) for rule in rules] 
-            self.assertFalse(
-                output_contains(tasks_derived, '<robin --> swimmer>. %0.90;0.73%')
-            )
-
         pass
 
     def test_uni_decomposition_2(self):
@@ -488,11 +456,11 @@ class TEST_NAL3(unittest.TestCase):
         'Boys are youth.
         ''outputMustContain('<boy --> youth>. %0.90;0.73%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<(|, boy, girl) --> youth>. %0.90;0.90% ', 
-            'boy.', 
-            '(|, boy, girl).', is_belief_term=True)
-        tasks_derived = [rule(task, belief.term, task_link, term_link) for rule in rules] 
+            None,
+            32
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<boy --> youth>. %0.90;0.73%')
         )
@@ -509,11 +477,11 @@ class TEST_NAL3(unittest.TestCase):
         'Boys are strong.
         ''outputMustContain('<boy --> [strong]>. %0.90;0.73%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<(~, boy, girl) --> [strong]>. %0.90;0.90%', 
-            'boy.', 
-            '(~, boy, girl).', is_belief_term=True)
-        tasks_derived = [rule(task, belief.term, task_link, term_link) for rule in rules] 
+            None,
+            32
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<boy --> [strong]>. %0.90;0.73%')
         )

--- a/Tests/test_NAL/test_NAL4.py
+++ b/Tests/test_NAL/test_NAL4.py
@@ -38,23 +38,15 @@ class TEST_NAL4(unittest.TestCase):
         'A base is something that has a reaction with an acid. 
         ''outputMustContain('<base --> (/,reaction,acid,_)>. %1.00;0.90%')
         '''
-        rules, task, concept, task_link, result1 = rule_map_task_only(
+        tasks_derived = process_two_premises(
             '<(*,acid, base) --> reaction>. %1.00;0.90%',
-            'acid',
-            (0,0)
+            None,
+            6
         )
-        tasks_derived = [rule(task, None, task_link, None) for rule in rules] 
 
         self.assertTrue(
             output_contains(tasks_derived, '<acid --> (/,reaction,_,base)>. %1.00;0.90%')
         )
-
-        rules, task, concept, task_link, result1 = rule_map_task_only(
-            '<(*,acid, base) --> reaction>. %1.00;0.90%',
-            'base',
-            (0,1)
-        )
-        tasks_derived = [rule(task, None, task_link, None) for rule in rules] 
 
         self.assertTrue(
             output_contains(tasks_derived, '<base --> (/,reaction,acid,_)>. %1.00;0.90%')
@@ -74,12 +66,11 @@ class TEST_NAL4(unittest.TestCase):
         'An acid and a base can have a reaction.
         ''outputMustContain('<(*,acid,base) --> reaction>. %1.00;0.90%')
         '''
-        rules, task, concept, task_link, result1 = rule_map_task_only(
+        tasks_derived = process_two_premises(
             '<acid --> (/,reaction,_,base)>. %1.00;0.90%',
-            'base',
-            (1,2)
+            None,
+            6
         )
-        tasks_derived = [rule(task, None, task_link, None) for rule in rules] 
         
         self.assertTrue(
             output_contains(tasks_derived, '<(*,acid,base) --> reaction>. %1.00;0.90%')
@@ -99,12 +90,11 @@ class TEST_NAL4(unittest.TestCase):
         'A base is something that has a reaction with an acid. 
         ''outputMustContain('<base --> (/,reaction,acid,_)>. %1.00;0.90%')
         '''
-        rules, task, concept, task_link, result1 = rule_map_task_only(
+        tasks_derived = process_two_premises(
             '<acid --> (/,reaction,_,base)>. %1.00;0.90%',
-            'base',
-            (1,2)
+            None,
+            6
         )
-        tasks_derived = [rule(task, None, task_link, None) for rule in rules] 
         
         self.assertTrue(
             output_contains(tasks_derived, '<base --> (/,reaction,acid,_)>. %1.00;0.90%')
@@ -124,12 +114,11 @@ class TEST_NAL4(unittest.TestCase):
         'Acid can react with base.
         ''outputMustContain('<acid --> (/,reaction,_,base)>. %1.00;0.90%')
         '''
-        rules, task, concept, task_link, result1 = rule_map_task_only(
+        tasks_derived = process_two_premises(
             '<base --> (/,reaction,acid,_)>. %1.00;0.90%',
-            'acid',
-            (1,1)
+            None,
+            6
         )
-        tasks_derived = [rule(task, None, task_link, None) for rule in rules] 
         
         self.assertTrue(
             output_contains(tasks_derived, '<acid --> (/,reaction,_,base)>. %1.00;0.90%')
@@ -149,12 +138,11 @@ class TEST_NAL4(unittest.TestCase):
         'Neutralization is a relation between an acid and a base. 
         ''outputMustContain('<neutralization --> (*,acid,base)>. %1.00;0.90%')
         '''
-        rules, task, concept, task_link, result1 = rule_map_task_only(
+        tasks_derived = process_two_premises(
             '<(\,neutralization,_,base) --> acid>. %1.00;0.90%',
-            'base',
-            (0,2)
+            None,
+            4
         )
-        tasks_derived = [rule(task, None, task_link, None) for rule in rules] 
         
         self.assertTrue(
             output_contains(tasks_derived, '<neutralization --> (*,acid,base)>. %1.00;0.90%')
@@ -174,12 +162,11 @@ class TEST_NAL4(unittest.TestCase):
         'Something that can be neutralized by an acid is a base.
         ''outputMustContain('<(\,neutralization,acid,_) --> base>. %1.00;0.90%')
         '''
-        rules, task, concept, task_link, result1 = rule_map_task_only(
+        tasks_derived = process_two_premises(
             '<(\,neutralization,_,base) --> acid>. %1.00;0.90%',
-            'base',
-            (0,2)
+            None,
+            6
         )
-        tasks_derived = [rule(task, None, task_link, None) for rule in rules] 
         
         self.assertTrue(
             output_contains(tasks_derived, '<(\,neutralization,acid,_) --> base>. %1.00;0.90%')
@@ -199,12 +186,11 @@ class TEST_NAL4(unittest.TestCase):
         'Something that can neutralize a base is an acid.
         ''outputMustContain('<(\,neutralization,_,base) --> acid>. %1.00;0.90%')
         '''
-        rules, task, concept, task_link, result1 = rule_map_task_only(
+        tasks_derived = process_two_premises(
             '<(\,neutralization,acid,_) --> base>. %1.00;0.90%',
-            'acid',
-            (0,1)
+            None,
+            6
         )
-        tasks_derived = [rule(task, None, task_link, None) for rule in rules] 
         
         self.assertTrue(
             output_contains(tasks_derived, '<(\,neutralization,_,base) --> acid>. %1.00;0.90%')
@@ -224,12 +210,11 @@ class TEST_NAL4(unittest.TestCase):
         'Neutralization is a relation between an acid and a base. 
         ''outputMustContain('<neutralization --> (*,acid,base)>. %1.00;0.90%')
         '''
-        rules, task, concept, task_link, result1 = rule_map_task_only(
+        tasks_derived = process_two_premises(
             '<(\,neutralization,acid,_) --> base>. %1.00;0.90%',
-            'acid',
-            (0,1)
+            None,
+            6
         )
-        tasks_derived = [rule(task, None, task_link, None) for rule in rules] 
         
         self.assertTrue(
             output_contains(tasks_derived, '<neutralization --> (*,acid,base)>. %1.00;0.90%')
@@ -252,11 +237,11 @@ class TEST_NAL4(unittest.TestCase):
         'The relation between bird and plant is a type of relation between animal and plant.
         ''outputMustContain('<(*,bird,plant) --> (*,animal,plant)>. %1.00;0.81%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<bird --> animal>. %1.00;0.90%', 
-            '(*,bird,plant).', 
-            'bird.', is_belief_term=True, index_task=(0,), index_belief=(0,))
-        tasks_derived = [rule(task, belief.term, task_link, term_link) for rule in rules] 
+            '<(*,bird,plant) --> ?x>?', 
+            6
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<(*,bird,plant) --> (*,animal,plant)>. %1.00;0.81%')
         )
@@ -277,11 +262,11 @@ class TEST_NAL4(unittest.TestCase):
         'What can be neutralized by acid can react with acid. 
         ''outputMustContain('<(\,neutralization,acid,_) --> (\,reaction,acid,_)>. %1.00;0.81%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<neutralization --> reaction>. %1.00;0.90%', 
-            '(\,neutralization,acid,_).', 
-            'neutralization.', is_belief_term=True, index_task=(0,), index_belief=(0,))
-        tasks_derived = [rule(task, belief.term, task_link, term_link) for rule in rules] 
+            '<(\,neutralization,acid,_) --> ?x>?', 
+            6
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<(\,neutralization,acid,_) --> (\,reaction,acid,_)>. %1.00;0.81%')
         )
@@ -303,11 +288,11 @@ class TEST_NAL4(unittest.TestCase):
         'What can neutraliz base can react with base. 
         ''outputMustContain('<(/,neutralization,_,base) --> (/,neutralization,_,soda)>. %1.00;0.81%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<soda --> base>. %1.00;0.90%', 
-            '(/,neutralization,_,base).', 
-            'base.', is_belief_term=True, index_task=(1,), index_belief=(2,))
-        tasks_derived = [rule(task, belief.term, task_link, term_link) for rule in rules] 
+            '<(/,neutralization,_,base) --> ?x>?', 
+            6
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<(/,neutralization,_,base) --> (/,neutralization,_,soda)>. %1.00;0.81%')
         )

--- a/Tests/test_NAL/test_NAL5.py
+++ b/Tests/test_NAL/test_NAL5.py
@@ -36,9 +36,10 @@ class TEST_NAL5(unittest.TestCase):
         'If robin can fly then robin is a type of bird. 
         ''outputMustContain('<<robin --> [flying]> ==> <robin --> bird>>. %0.86;0.91%')
         '''
-        tasks_derived = memory_accept_revision(
+        tasks_derived = process_two_premises(
             '<<robin --> [flying]> ==> <robin --> bird>>. %1.00;0.90%',
-            '<<robin --> [flying]> ==> <robin --> bird>>. %0.00;0.60% '
+            '<<robin --> [flying]> ==> <robin --> bird>>. %0.00;0.60% ',
+            2
         )
         self.assertTrue(
             output_contains(tasks_derived, '<<robin --> [flying]> ==> <robin --> bird>>. %0.86;0.91%')
@@ -62,11 +63,11 @@ class TEST_NAL5(unittest.TestCase):
         'If robin can fly then robin is a type of animal. 
         ''outputMustContain('<<robin --> [flying]> ==> <robin --> animal>>. %1.00;0.81%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<<robin --> bird> ==> <robin --> animal>>. %1.00;0.9%', 
             '<<robin --> [flying]> ==> <robin --> bird>>. %1.00;0.9%', 
-            '<robin --> bird>.', index_task=(0,), index_belief=(1,))
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+            14
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<<robin --> [flying]> ==> <robin --> animal>>. %1.00;0.81%')
         )
@@ -87,11 +88,11 @@ class TEST_NAL5(unittest.TestCase):
         'I guess if robin is a type of animal then robin can fly. 
         ''outputMustContain('<<robin --> animal> ==> <robin --> [flying]>>. %1.00;0.45%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<<robin --> [flying]> ==> <robin --> bird>>. %1.00;0.90%', 
             '<<robin --> bird> ==> <robin --> animal>>. %1.00;0.90%', 
-            '<robin --> bird>.', index_task=(1,), index_belief=(0,))
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+            19
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<<robin --> animal> ==> <robin --> [flying]>>. %1.00;0.45%')
         )
@@ -116,16 +117,14 @@ class TEST_NAL5(unittest.TestCase):
         'I guess if robin is a type of animal then robin can fly. 
         ''outputMustContain('<<robin --> animal> ==> <robin --> [flying]>>. %0.80;0.45%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<<robin --> bird> ==> <robin --> animal>>. %1.00;0.90%', 
             '<<robin --> bird> ==> <robin --> [flying]>>. %0.80;0.90%', 
-            '<robin --> bird>.', index_task=(0,), index_belief=(0,))
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+            14
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<<robin --> animal> ==> <robin --> [flying]>>. %0.80;0.45%')
         )
-        # for task in tasks_derived:
-        #     print(task)
         pass
 
 
@@ -147,16 +146,14 @@ class TEST_NAL5(unittest.TestCase):
         'I guess if robin can fly then robin is a type of bird.
         ''outputMustContain('<<robin --> [flying]> ==> <robin --> bird>>. %0.80;0.45%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<<robin --> bird> ==> <robin --> animal>>. %1.00;0.90%', 
             '<<robin --> [flying]> ==> <robin --> animal>>. %0.80;0.90%', 
-            '<robin --> animal>.', index_task=(1,), index_belief=(1,))
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+            19
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<<robin --> [flying]> ==> <robin --> bird>>. %0.80;0.45%')
         )
-        for task in tasks_derived:
-            print(task)
         pass
 
     
@@ -175,20 +172,19 @@ class TEST_NAL5(unittest.TestCase):
         'Robin is a type of animal. 
         ''outputMustContain('<robin --> animal>. %1.00;0.81%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<<robin --> bird> ==> <robin --> animal>>. %1.00;0.90%', 
             '<robin --> bird>. %1.00;0.90%', 
-            '<robin --> bird>.', index_task=(0,), index_belief=())
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+            6)
         self.assertTrue(
             output_contains(tasks_derived, '<robin --> animal>. %1.00;0.81%')
         )
 
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<robin --> bird>. %1.00;0.90%', 
             '<<robin --> bird> ==> <robin --> animal>>. %1.00;0.90%', 
-            '<robin --> bird>.', index_task=(), index_belief=(0,))
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+            6
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<robin --> animal>. %1.00;0.81%')
         )
@@ -210,11 +206,11 @@ class TEST_NAL5(unittest.TestCase):
         'I guess robin is a type of bird. 
         ''outputMustContain('<robin --> bird>. %1.00;0.36%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<<robin --> bird> ==> <robin --> animal>>. %0.70;0.90%', 
             '<robin --> animal>. %1.00;0.90%', 
-            '<robin --> animal>.', True, index_task=(), index_belief=(1, ))
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+            6
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<robin --> bird>. %1.00;0.36%')
         )
@@ -236,11 +232,11 @@ class TEST_NAL5(unittest.TestCase):
         'I guess robin is a type of bird. 
         ''outputMustContain('<robin --> bird>. %1.00;0.36%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<<robin --> bird> ==> <robin --> animal>>. %0.70;0.90%', 
             '<robin --> animal>. %1.00;0.90%', 
-            'animal.', index_task=(1,1), index_belief=(1, ))
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+            6
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<robin --> bird>. %1.00;0.36%')
         )
@@ -263,11 +259,11 @@ class TEST_NAL5(unittest.TestCase):
         'I guess robin is a type of animal if and only if robin can fly.
         ''outputMustContain('<<robin --> [flying]> <=> <robin --> animal>>. %0.80;0.45%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<<robin --> bird> ==> <robin --> animal>>. %1.00;0.90%', 
             '<<robin --> bird> ==> <robin --> [flying]>>. %0.80;0.90%', 
-            '<robin --> bird>.', index_task=(0,), index_belief=(0,))
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+            14
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<<robin --> [flying]> <=> <robin --> animal>>. %0.80;0.45%')
         )
@@ -289,11 +285,11 @@ class TEST_NAL5(unittest.TestCase):
         'I guess robin is a type of bird if and only if robin can fly. 
         ''outputMustContain('<<robin --> [flying]> <=> <robin --> bird>>. %0.70;0.45%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<<robin --> bird> ==> <robin --> animal>>. %0.70;0.90%', 
             '<<robin --> [flying]> ==> <robin --> animal>>. %1.00;0.90%', 
-            '<robin --> animal>.', index_task=(1,), index_belief=(1,))
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+            19
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<<robin --> [flying]> <=> <robin --> bird>>. %0.70;0.45%')
         )
@@ -315,11 +311,11 @@ class TEST_NAL5(unittest.TestCase):
         'If robin can fly then probably robin is a type of animal. 
         ''outputMustContain('<<robin --> [flying]> ==> <robin --> animal>>. %0.80;0.65%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<<robin --> bird> ==> <robin --> animal>>. %1.00;0.90%', 
             '<<robin --> bird> <=> <robin --> [flying]>>. %0.80;0.90%', 
-            '<robin --> bird>.', index_task=(0,), index_belief=(0,))
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+            14
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<<robin --> [flying]> ==> <robin --> animal>>. %0.80;0.65%')
         )
@@ -341,39 +337,39 @@ class TEST_NAL5(unittest.TestCase):
         'I guess usually robin can fly.
         ''outputMustContain('<robin --> [flying]>. %0.80;0.65%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<robin --> bird>. %1.00;0.90%', 
             '<<robin --> bird> <=> <robin --> [flying]>>. %0.80;0.90%', 
-            '<robin --> bird>.', index_task=(), index_belief=(0,))
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+            6
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<robin --> [flying]>. %0.80;0.65%')
         )
 
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<<robin --> bird> <=> <robin --> [flying]>>. %0.80;0.90%', 
             '<robin --> bird>. %1.00;0.90%', 
-            '<robin --> bird>.', index_task=(0,), index_belief=())
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+            6
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<robin --> [flying]>. %0.80;0.65%')
         )
 
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<robin --> bird>. %1.00;0.90%', 
             '<<robin --> [flying]> <=> <robin --> bird>>. %0.80;0.90%', 
-            '<robin --> bird>.', index_task=(), index_belief=(0,))
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+            6
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<robin --> [flying]>. %0.80;0.65%')
         )
 
 
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<<robin --> [flying]> <=> <robin --> bird>>. %0.80;0.90%', 
             '<robin --> bird>. %1.00;0.90%', 
-            '<robin --> bird>.', index_task=(0,), index_belief=())
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+            6
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<robin --> [flying]>. %0.80;0.65%')
         )
@@ -395,11 +391,11 @@ class TEST_NAL5(unittest.TestCase):
         'Robin is a type of animal if and only if robin can fly. 
         ''outputMustContain('<<robin --> [flying]> <=> <robin --> animal>>. %0.90;0.81%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<<robin --> animal> <=> <robin --> bird>>. %1.00;0.90%', 
             '<<robin --> bird> <=> <robin --> [flying]>>. %0.90;0.90% ', 
-            '<robin --> bird>.', index_task=(1,), index_belief=(0,))
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+            19
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<<robin --> [flying]> <=> <robin --> animal>>. %0.90;0.81%')
         )
@@ -421,11 +417,11 @@ class TEST_NAL5(unittest.TestCase):
         'Robin can fly if and only if robin is a type of bird. 
         ''outputMustContain('<<robin --> [flying]> <=> <robin --> bird>>. %0.81;0.81%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<<robin --> [flying]> ==> <robin --> bird>>. %0.90;0.90%', 
             '<<robin --> bird> ==> <robin --> [flying]>>. %0.90;0.90%', 
-            '<robin --> bird>.', index_task=(1,), index_belief=(0,))
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+            7
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<<robin --> [flying]> <=> <robin --> bird>>. %0.81;0.81%')
         )
@@ -447,21 +443,11 @@ class TEST_NAL5(unittest.TestCase):
         'If robin is a type of bird then usually robin is a type of animal and can fly. 
         ''outputMustContain('<<robin --> bird> ==> (&&,<robin --> [flying]>,<robin --> animal>)>. %0.90;0.81%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<<robin --> bird> ==> <robin --> animal>>. %1.00;0.90%', 
             '<<robin --> bird> ==> <robin --> [flying]>>. %0.90;0.90%', 
-            '<robin --> bird>.', index_task=(0,), index_belief=(0,))
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
-        self.assertTrue(
-            output_contains(tasks_derived, '<<robin --> bird> ==> (&&,<robin --> [flying]>,<robin --> animal>)>. %0.90;0.81%')
+            14
         )
-
-
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
-            '<<robin --> bird> ==> <robin --> animal>>. %1.00;0.90%', 
-            '<<robin --> bird> ==> <robin --> [flying]>>. %0.90;0.90%', 
-            'robin.', index_task=(0,0), index_belief=(0,0))
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
         self.assertTrue(
             output_contains(tasks_derived, '<<robin --> bird> ==> (&&,<robin --> [flying]>,<robin --> animal>)>. %0.90;0.81%')
         )
@@ -483,11 +469,11 @@ class TEST_NAL5(unittest.TestCase):
         'If robin can fly and is a type of bird then robin is a type of animal. 
         ''outputMustContain('<(&&,<robin --> [flying]>,<robin --> bird>) ==> <robin --> animal>>. %1.00;0.81%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<<robin --> bird> ==> <robin --> animal>>. %1.00;0.90%', 
             '<<robin --> [flying]> ==> <robin --> animal>>. %0.90;0.90% ', 
-            '<robin --> animal>.', index_task=(1,), index_belief=(1,))
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+            19
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<(&&,<robin --> [flying]>,<robin --> bird>) ==> <robin --> animal>>. %1.00;0.81%')
         )
@@ -509,11 +495,11 @@ class TEST_NAL5(unittest.TestCase):
         'If robin is a type of bird then robin is a type of animal or can fly. 
         ''outputMustContain('<<robin --> bird> ==> (||,<robin --> [flying]>,<robin --> animal>)>. %1.00;0.81%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<<robin --> bird> ==> <robin --> animal>>. %1.00;0.90%', 
             '<<robin --> bird> ==> <robin --> [flying]>>. %0.90;0.90%', 
-            '<robin --> bird>.', index_task=(0,), index_belief=(0,))
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+            14
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<<robin --> bird> ==> (||,<robin --> [flying]>,<robin --> animal>)>. %1.00;0.81%')
         )
@@ -534,11 +520,11 @@ class TEST_NAL5(unittest.TestCase):
         'If robin can fly or is a type of bird then robin is a type of animal. 
         ''outputMustContain('<(||,<robin --> [flying]>,<robin --> bird>) ==> <robin --> animal>>. %0.90;0.81%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<<robin --> bird> ==> <robin --> animal>>. %1.00;0.90%', 
             '<<robin --> [flying]> ==> <robin --> animal>>. %0.90;0.90% ', 
-            '<robin --> animal>.', index_task=(1,), index_belief=(1,))
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+            19
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<(||,<robin --> [flying]>,<robin --> bird>) ==> <robin --> animal>>. %0.90;0.81%')
         )
@@ -560,11 +546,11 @@ class TEST_NAL5(unittest.TestCase):
         'It is unlikely that if a robin is a type of bird then robin is a type of animal. 
         ''outputMustContain('<<robin --> bird> ==> <robin --> animal>>. %0.00;0.81%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<<robin --> bird> ==> (&&,<robin --> animal>,<robin --> [flying]>)>. %0.00;0.90%', 
             '<<robin --> bird> ==> <robin --> [flying]>>. %1.00;0.90%', 
-            '<robin --> bird>.', index_task=(0,), index_belief=(0,))
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+            8
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<<robin --> bird> ==> <robin --> animal>>. %0.00;0.81%')
         )
@@ -586,42 +572,24 @@ class TEST_NAL5(unittest.TestCase):
         'Robin cannot swim. 
         ''outputMustContain('<robin --> swimmer>. %0.00;0.81%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '(&&,<robin --> [flying]>,<robin --> swimmer>). %0.00;0.90% ', 
             '<robin --> [flying]>. %1.00;0.90%', 
-            'robin.')
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+            6
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<robin --> swimmer>. %0.00;0.81%')
         )
 
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
-            '(&&,<robin --> [flying]>,<robin --> swimmer>). %0.00;0.90% ', 
+        tasks_derived = process_two_premises(
             '<robin --> [flying]>. %1.00;0.90%', 
-            '(&&,<robin --> [flying]>,<robin --> swimmer>).')
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+            '(&&,<robin --> [flying]>,<robin --> swimmer>). %0.00;0.90% ', 
+            6
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<robin --> swimmer>. %0.00;0.81%')
         )
 
-
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
-            '<robin --> [flying]>. %1.00;0.90%', 
-            '(&&,<robin --> [flying]>,<robin --> swimmer>). %0.00;0.90% ', 
-            'robin.')
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
-        self.assertTrue(
-            output_contains(tasks_derived, '<robin --> swimmer>. %0.00;0.81%')
-        )
-
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
-            '<robin --> [flying]>. %1.00;0.90%', 
-            '(&&,<robin --> [flying]>,<robin --> swimmer>). %0.00;0.90% ', 
-            '<robin --> [flying]>.')
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
-        self.assertTrue(
-            output_contains(tasks_derived, '<robin --> swimmer>. %0.00;0.81%')
-        )
         pass
 
 
@@ -640,11 +608,11 @@ class TEST_NAL5(unittest.TestCase):
         'Robin can fly. 
         ''outputMustContain('<robin --> [flying]>. %1.00;0.81%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '(||,<robin --> [flying]>,<robin --> swimmer>). %1.00;0.90% ', 
             '<robin --> swimmer>. %0.00;0.90%', 
-            'robin.', index_task=(0,0), index_belief=(0,))
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+            6
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<robin --> [flying]>. %1.00;0.81%')
         )
@@ -666,23 +634,15 @@ class TEST_NAL5(unittest.TestCase):
         'Robin can fly or swim.
         ''outputMustContain('(||,<robin --> [flying]>,<robin --> swimmer>). %1.00;0.81%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<robin --> [flying]>. %1.00;0.90%', 
             '(||,<robin --> [flying]>,<robin --> swimmer>)?', 
-            '<robin --> [flying]>.', is_belief_term=True, index_task=(), index_belief=(0,))
-        tasks_derived = [rule(task, belief.term, task_link, term_link) for rule in rules] 
+            7
+        )
         self.assertTrue(
             output_contains(tasks_derived, '(||,<robin --> [flying]>,<robin --> swimmer>). %1.00;0.81%')
         )
-
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
-            '<robin --> [flying]>. %1.00;0.90%', 
-            '(||,<robin --> [flying]>,<robin --> swimmer>)?', 
-            'robin.', is_belief_term=True, index_task=(0,), index_belief=(0,0))
-        tasks_derived = [rule(task, belief.term, task_link, term_link) for rule in rules] 
-        self.assertTrue(
-            output_contains(tasks_derived, '(||,<robin --> [flying]>,<robin --> swimmer>). %1.00;0.81%')
-        )
+        pass
 
 
     def test_composition_1(self):
@@ -704,39 +664,14 @@ class TEST_NAL5(unittest.TestCase):
         'Robin can fly. 
         ''outputMustContain('<robin --> [flying]>. %0.90;0.73%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '$0.90;0.90$ (&&,<robin --> swimmer>,<robin --> [flying]>). %0.90;0.90%', 
-            '<robin --> swimmer>.', 
-            '(&&,<robin --> swimmer>,<robin --> [flying]>).', is_belief_term=True, index_task=(), index_belief=(0,))
-        tasks_derived = [rule(task, belief.term, task_link, term_link) for rule in rules] 
+            6
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<robin --> swimmer>. %0.90;0.73%')
         )
 
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
-            '$0.90;0.90$ (&&,<robin --> swimmer>,<robin --> [flying]>). %0.90;0.90%', 
-            '<robin --> [flying]>.', 
-            '(&&,<robin --> swimmer>,<robin --> [flying]>).', is_belief_term=True, index_task=(), index_belief=(1,))
-        tasks_derived = [rule(task, belief.term, task_link, term_link) for rule in rules] 
-        self.assertTrue(
-            output_contains(tasks_derived, '<robin --> [flying]>. %0.90;0.73%')
-        )
-
-
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
-            '$0.90;0.90$ (&&,<robin --> swimmer>,<robin --> [flying]>). %0.90;0.90%', 
-            '<robin --> swimmer>.', 
-            'robin.', is_belief_term=True, index_task=(0,0), index_belief=(0,))
-        tasks_derived = [rule(task, belief.term, task_link, term_link) for rule in rules] 
-        self.assertTrue(
-            output_contains(tasks_derived, '<robin --> swimmer>. %0.90;0.73%')
-        )
-
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
-            '$0.90;0.90$ (&&,<robin --> swimmer>,<robin --> [flying]>). %0.90;0.90%', 
-            '<robin --> [flying]>.', 
-            'robin.', is_belief_term=True, index_task=(1,0), index_belief=(0,))
-        tasks_derived = [rule(task, belief.term, task_link, term_link) for rule in rules] 
         self.assertTrue(
             output_contains(tasks_derived, '<robin --> [flying]>. %0.90;0.73%')
         )
@@ -755,49 +690,13 @@ class TEST_NAL5(unittest.TestCase):
         ''outputMustContain('<robin --> [flying]>. %0.90;0.90%')
         '''
 
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
-            '<robin --> [flying]>. %0.90;0.90%', 
-            '(--,<robin --> [flying]>)?', 
-            '<robin --> [flying]>.', is_belief_term=True, index_task=(), index_belief=(0,))
-        tasks_derived = [rule(task, belief.term, task_link, term_link) for rule in rules] 
-        self.assertTrue(
-            output_contains(tasks_derived, '(--,<robin --> [flying]>). %0.10;0.90%')
-        )
-
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
-            '<robin --> [flying]>. %0.90;0.90%', 
-            '(--,<robin --> [flying]>)?', 
-            'robin.', is_belief_term=True, index_task=(0,), index_belief=(0,0))
-        tasks_derived = [rule(task, belief.term, task_link, term_link) for rule in rules] 
-        self.assertTrue(
-            output_contains(tasks_derived, '(--,<robin --> [flying]>). %0.10;0.90%')
-        )
-
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '(--,<robin --> [flying]>). %0.10;0.90%', 
-            '<robin --> [flying]>.', 
-            'robin.', is_belief_term=True, index_task=(0,0), index_belief=(0,))
-        tasks_derived = [rule(task, belief.term, task_link, term_link) for rule in rules] 
-        self.assertTrue(
-            output_contains(tasks_derived, '<robin --> [flying]>. %0.90;0.90%')
+            '<robin --> [flying]>?',
+            3
         )
-
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
-            '(--,<robin --> [flying]>). %0.10;0.90%', 
-            'robin.', 
-            '(--,<robin --> [flying]>).', is_belief_term=True, index_task=(), index_belief=(0,0))
-        tasks_derived = [rule(task, belief.term, task_link, term_link) for rule in rules] 
         self.assertTrue(
-            output_contains(tasks_derived, '<robin --> [flying]>. %0.90;0.90%')
-        )
-
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
-            '(--,<robin --> [flying]>). %0.10;0.90%', 
-            '<robin --> [flying]>.', 
-            '(--,<robin --> [flying]>).', is_belief_term=True, index_task=(), index_belief=(0,))
-        tasks_derived = [rule(task, belief.term, task_link, term_link) for rule in rules] 
-        self.assertTrue(
-            output_contains(tasks_derived, '<robin --> [flying]>. %0.90;0.90%')
+            output_contains(tasks_derived, '<robin --> [flying]>. %0.10;0.90%')
         )
 
     
@@ -818,20 +717,11 @@ class TEST_NAL5(unittest.TestCase):
         ''outputMustContain('(--,<robin --> [flying]>). %0.10;0.90%')
         '''
 
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<robin --> [flying]>. %0.90;0.90%', 
             '(--,<robin --> [flying]>)?', 
-            '<robin --> [flying]>.', is_belief_term=True, index_task=(), index_belief=(0,))
-        tasks_derived = [rule(task, belief.term, task_link, term_link) for rule in rules] 
-        self.assertTrue(
-            output_contains(tasks_derived, '(--,<robin --> [flying]>). %0.10;0.90%')
+            30
         )
-
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
-            '<robin --> [flying]>. %0.90;0.90%', 
-            '(--,<robin --> [flying]>)?', 
-            'robin.', is_belief_term=True, index_task=(0,), index_belief=(0,0))
-        tasks_derived = [rule(task, belief.term, task_link, term_link) for rule in rules] 
         self.assertTrue(
             output_contains(tasks_derived, '(--,<robin --> [flying]>). %0.10;0.90%')
         )
@@ -854,26 +744,16 @@ class TEST_NAL5(unittest.TestCase):
 
         561
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<(--,<robin --> bird>) ==> <robin --> [flying]>>. %0.10;0.90%', 
-            '<robin --> bird>.', 
-            '(--,<robin --> bird>).', is_belief_term=True, index_task=(0,), index_belief=(0,))
-        tasks_derived = [rule(task, belief.term, task_link, term_link) for rule in rules] 
+            '<(--,<robin --> [flying]>) ==> <robin --> bird>>?', 
+            30,
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<(--,<robin --> [flying]>) ==> <robin --> bird>>. %0.00;0.45%')
         )
         pass
 
-        # rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
-        #     '<(--,<robin --> bird>) ==> <robin --> [flying]>>. %0.10;0.90%', 
-        #     '<(--,<robin --> [flying]>) ==> <robin --> bird>>?', 
-        #     '<robin --> [flying]>.', is_belief_term=True, index_task=(1,), index_belief=(0,0))
-        # tasks_derived = [rule(task, belief.term, task_link, term_link) for rule in rules] 
-        # self.assertTrue(
-        #     output_contains(tasks_derived, '<(--,<robin --> [flying]>) ==> <robin --> bird>>. %0.00;0.45%')
-        # )
-        # pass
-        
 
     def test_conditional_deduction_compound_eliminate_0(self):
         '''
@@ -890,25 +770,24 @@ class TEST_NAL5(unittest.TestCase):
         'If robin has wings then robin is a bird
         ''outputMustContain('<<robin --> [with_wings]> ==> <robin --> bird>>. %1.00;0.81%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<(&&,<robin --> [flying]>,<robin --> [with_wings]>) ==> <robin --> bird>>. %1.00;0.90%', 
             '<robin --> [flying]>. %1.00;0.90%', 
-            'robin.', index_task=(0,0,0), index_belief=(0,))
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+            2
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<<robin --> [with_wings]> ==> <robin --> bird>>. %1.00;0.81%')
         )
-        pass
 
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<robin --> [flying]>. %1.00;0.90%', 
             '<(&&,<robin --> [flying]>,<robin --> [with_wings]>) ==> <robin --> bird>>. %1.00;0.90%', 
-            'robin.', index_task=(0,), index_belief=(0,0,0))
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+            2
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<<robin --> [with_wings]> ==> <robin --> bird>>. %1.00;0.81%')
         )
-        pass
+
 
     def test_conditional_deduction_compound_eliminate_1(self):
         '''

--- a/Tests/test_NAL/test_NAL6.py
+++ b/Tests/test_NAL/test_NAL6.py
@@ -27,9 +27,10 @@ class TEST_NAL6(unittest.TestCase):
         'If something is a bird, then usually, it is a flyer. 
         ''outputMustContain('<<$1 --> bird> ==> <$1 --> flyer>>. %0.79;0.92%')
         '''
-        tasks_derived = memory_accept_revision(
+        tasks_derived = process_two_premises(
             '<<$x --> bird> ==> <$x --> flyer>>. %1.00;0.90%',
-            '<<$y --> bird> ==> <$y --> flyer>>. %0.00;0.70%'
+            '<<$y --> bird> ==> <$y --> flyer>>. %0.00;0.70%',
+            2
         )
         self.assertTrue(
             output_contains(tasks_derived, '<<$1 --> bird> ==> <$1 --> flyer>>. %0.79;0.92%')
@@ -55,27 +56,20 @@ class TEST_NAL6(unittest.TestCase):
         'I guess that if something is a animal, then it is a robin. 
         ''outputMustContain('<<$1 --> animal> ==> <$1 --> robin>>. %1.00;0.45%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<<$x --> bird> ==> <$x --> animal>>. %1.00;0.90%',
             '<<$y --> robin> ==> <$y --> bird>>. %1.00;0.90%',
-            '<$x --> bird>.', index_task=(0,), index_belief=(1,)
-        )
-        self.assertNotEqual(rules, None)
-
-        subst_var = get_substitution__var_var(task.term, belief.term, [0], [1]) # to find possible replacement.
-        subst_var.apply(task.term, belief.term)
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
-
-        repr(tasks_derived[0].term)
-        self.assertTrue(
-            output_contains(tasks_derived, '<<$1 --> robin> ==> <$1 --> animal>>. %1.00;0.81%')
+            10
         )
         self.assertTrue(
-            output_contains(tasks_derived, '<<$1 --> animal> ==> <$1 --> robin>>. %1.00;0.45%')
+            output_contains(tasks_derived, '<<$0 --> robin> ==> <$0 --> animal>>. %1.00;0.81%')
+        )
+        self.assertTrue(
+            output_contains(tasks_derived, '<<$0 --> animal> ==> <$0 --> robin>>. %1.00;0.45%')
         )
 
         self.assertTrue(
-            not output_contains(tasks_derived, '<<$1 --> animal> ==> <$2 --> robin>>. %1.00;0.45%')
+            not output_contains(tasks_derived, '<<$0 --> animal> ==> <$1 --> robin>>. %1.00;0.45%')
         )
         pass
 
@@ -108,32 +102,26 @@ class TEST_NAL6(unittest.TestCase):
         ''outputMustContain('<<$1 --> bird> <=> <$1 --> swimmer>>. %0.80;0.42%')
         '''
 
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<<$x --> swan> ==> <$x --> bird>>. %1.00;0.80% ',
             '<<$y --> swan> ==> <$y --> swimmer>>. %0.80;0.90%',
-            '<$x --> swan>.'
+            10
         )
-        self.assertNotEqual(rules, None)
-
-        subst_var = get_substitution__var_var(task.term, belief.term, [0], [0]) # to find possible replacement.
-        subst_var.apply(task.term, belief.term)
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
-
 
         self.assertTrue(
-            output_contains(tasks_derived, '<<$1 --> swan> ==> (||,<$1 --> bird>,<$1 --> swimmer>)>. %1.00;0.72%')
+            output_contains(tasks_derived, '<<$0 --> swan> ==> (||,<$0 --> bird>,<$0 --> swimmer>)>. %1.00;0.72%')
         )
         self.assertTrue(
-            output_contains(tasks_derived, '<<$1 --> swan> ==> (&&,<$1 --> bird>,<$1 --> swimmer>)>. %0.80;0.72%')
+            output_contains(tasks_derived, '<<$0 --> swan> ==> (&&,<$0 --> bird>,<$0 --> swimmer>)>. %0.80;0.72%')
         )
         self.assertTrue(
-            output_contains(tasks_derived, '<<$1 --> swimmer> ==> <$1 --> bird>>. %1.00;0.37%')
+            output_contains(tasks_derived, '<<$0 --> swimmer> ==> <$0 --> bird>>. %1.00;0.37%')
         )
         self.assertTrue(
-            output_contains(tasks_derived, '<<$1 --> bird> ==> <$1 --> swimmer>>. %0.80;0.42%')
+            output_contains(tasks_derived, '<<$0 --> bird> ==> <$0 --> swimmer>>. %0.80;0.42%')
         )
         self.assertTrue(
-            output_contains(tasks_derived, '<<$1 --> bird> <=> <$1 --> swimmer>>. %0.80;0.42%')
+            output_contains(tasks_derived, '<<$0 --> bird> <=> <$0 --> swimmer>>. %0.80;0.42%')
         )
         pass
 
@@ -165,31 +153,26 @@ class TEST_NAL6(unittest.TestCase):
         'I guess bird and swimmer share most properties.
         ''outputMustContain('<<bird --> $1> <=> <swimmer --> $1>>. %0.70;0.45%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<<bird --> $x> ==> <robin --> $x>>. %1.00;0.90%',
             '<<swimmer --> $y> ==> <robin --> $y>>. %0.70;0.90%',
-            '<robin --> $x>.'
+            10
         )
-        self.assertNotEqual(rules, None)
-
-        subst_var = get_substitution__var_var(task.term, belief.term, [1], [1]) # to find possible replacement.
-        subst_var.apply(task.term, belief.term)
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
-
+        
         self.assertTrue(
-            output_contains(tasks_derived, '<(&&,<bird --> $1>,<swimmer --> $1>) ==> <robin --> $1>>. %1.00;0.81%')
+            output_contains(tasks_derived, '<(&&,<bird --> $0>,<swimmer --> $0>) ==> <robin --> $0>>. %1.00;0.81%')
         )
         self.assertTrue(
-            output_contains(tasks_derived, '<(||,<bird --> $1>,<swimmer --> $1>) ==> <robin --> $1>>. %0.70;0.81%')
+            output_contains(tasks_derived, '<(||,<bird --> $0>,<swimmer --> $0>) ==> <robin --> $0>>. %0.70;0.81%')
         )
         self.assertTrue(
-            output_contains(tasks_derived, '<<bird --> $1> ==> <swimmer --> $1>>. %1.00;0.36%')
+            output_contains(tasks_derived, '<<bird --> $0> ==> <swimmer --> $0>>. %1.00;0.36%')
         )
         self.assertTrue(
-            output_contains(tasks_derived, '<<swimmer --> $1> ==> <bird --> $1>>. %0.70;0.45%')
+            output_contains(tasks_derived, '<<swimmer --> $0> ==> <bird --> $0>>. %0.70;0.45%')
         )
         self.assertTrue(
-            output_contains(tasks_derived, '<<bird --> $1> <=> <swimmer --> $1>>. %0.70;0.45%')
+            output_contains(tasks_derived, '<<bird --> $0> <=> <swimmer --> $0>>. %0.70;0.45%')
         )
 
 
@@ -208,19 +191,14 @@ class TEST_NAL6(unittest.TestCase):
         'If something can chirp and has wings, then it is a bird.
         ''outputMustContain('<(&&,<$1 --> [chirping]>,<$1 --> [with_wings]>) ==> <$1 --> bird>>. %1.00;0.81%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<(&&,<$x --> flyer>,<$x --> [chirping]>) ==> <$x --> bird>>. %1.00;0.90%',
             '<<$y --> [with_wings]> ==> <$y --> flyer>>. %1.00;0.90%',
-            '<$y --> flyer>.'
+            10
         )
-        self.assertNotEqual(rules, None)
-
-        subst_var = get_substitution__var_var(task.term, belief.term, [0,0], [1]) # to find possible replacement.
-        subst_var.apply(task.term, belief.term)
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
-
+        
         self.assertTrue(
-            output_contains(tasks_derived, '<(&&,<$1 --> [chirping]>,<$1 --> [with_wings]>) ==> <$1 --> bird>>. %1.00;0.81%')
+            output_contains(tasks_derived, '<(&&,<$0 --> [chirping]>,<$0 --> [with_wings]>) ==> <$0 --> bird>>. %1.00;0.81%')
         )
         pass
 
@@ -244,22 +222,17 @@ class TEST_NAL6(unittest.TestCase):
         'I guess if something has wings, then it can fly and eats worms.
         ''outputMustContain('<<$1 --> [with_wings]> ==> (&&,<$1 --> flyer>,<(*,$1,worms) --> food>)>. %1.00;0.45%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<(&&,<$x --> flyer>,<$x --> [chirping]>, <(*, $x, worms) --> food>) ==> <$x --> bird>>.  %1.00;0.90%',
             '<(&&,<$x --> [chirping]>,<$x --> [with_wings]>) ==> <$x --> bird>>. %1.00;0.90%',
-            'chirping.'
+            10
         )
-        self.assertNotEqual(rules, None)
-
-        subst_var = get_substitution__var_var(task.term, belief.term, [1], [1]) # to find possible replacement.
-        subst_var.apply(task.term, belief.term)
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
-
+        
         self.assertTrue(
-            output_contains(tasks_derived, '<(&&,<$1 --> flyer>,<(*,$1,worms) --> food>) ==> <$1 --> [with_wings]>>. %1.00;0.45%')
+            output_contains(tasks_derived, '<(&&,<$0 --> flyer>,<(*,$0,worms) --> food>) ==> <$0 --> [with_wings]>>. %1.00;0.45%')
         )
         self.assertTrue(
-            output_contains(tasks_derived, '<<$1 --> [with_wings]> ==> (&&,<$1 --> flyer>,<(*,$1,worms) --> food>)>. %1.00;0.45%')
+            output_contains(tasks_derived, '<<$0 --> [with_wings]> ==> (&&,<$0 --> flyer>,<(*,$0,worms) --> food>)>. %1.00;0.45%')
         )
         pass
 
@@ -291,17 +264,14 @@ class TEST_NAL6(unittest.TestCase):
         'If something has wings and eats worms, then I guess it is a bird.
         ''outputMustContain('<(&&,<$1 --> [with_wings]>,<(*,$1,worms) --> food>) ==> <$1 --> bird>>. %1.00;0.45%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<(&&,<$x --> flyer>,<(*,$x,worms) --> food>) ==> <$x --> bird>>. %1.00;0.90%',
             '<<$y --> flyer> ==> <$y --> [with_wings]>>. %1.00;0.90%',
-            'flyer.'
+            10
         )
-        self.assertNotEqual(rules, None)
-
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
-
+       
         self.assertTrue(
-            output_contains(tasks_derived, '<(&&,<$1 --> [with_wings]>,<(*,$1,worms) --> food>) ==> <$1 --> bird>>. %1.00;0.45%')
+            output_contains(tasks_derived, '<(&&,<$0 --> [with_wings]>,<(*,$0,worms) --> food>) ==> <$0 --> bird>>. %1.00;0.45%')
         )
         pass
 
@@ -321,16 +291,12 @@ class TEST_NAL6(unittest.TestCase):
         'A robin is an animal.
         ''outputMustContain('<robin --> animal>. %1.00;0.81%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<<$x --> bird> ==> <$x --> animal>>. %1.00;0.90%',
             '<robin --> bird>. %1.00;0.90%',
-            'bird.'
+            3
         )
-        self.assertNotEqual(rules, None)
-
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
-
-
+        
         self.assertTrue(
             output_contains(tasks_derived, '<robin --> animal>. %1.00;0.81%')
         )
@@ -352,15 +318,11 @@ class TEST_NAL6(unittest.TestCase):
         'I guess that a tiger is a bird.
         ''outputMustContain('<tiger --> bird>. %1.00;0.45%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<<$x --> bird> ==> <$x --> animal>>. %1.00;0.90%',
             '<tiger --> animal>. %1.00;0.90%',
-            'animal.'
+            10
         )
-        self.assertNotEqual(rules, None)
-
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
-
 
         self.assertTrue(
             output_contains(tasks_derived, '<tiger --> bird>. %1.00;0.45%')
@@ -383,15 +345,11 @@ class TEST_NAL6(unittest.TestCase):
         'A robin is a animal.
         ''outputMustContain('<robin --> animal>. %1.00;0.81%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<<$x --> animal> <=> <$x --> bird>>. %1.00;0.90%',
             '<robin --> bird>. %1.00;0.90%',
-            'bird.'
+            3
         )
-        self.assertNotEqual(rules, None)
-
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
-
 
         self.assertTrue(
             output_contains(tasks_derived, '<robin --> animal>. %1.00;0.81%')
@@ -414,15 +372,11 @@ class TEST_NAL6(unittest.TestCase):
         'I guess swan can swim.
         ''outputMustContain('<swan --> swimmer>. %0.90;0.43%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '(&&,<#x --> bird>,<#x --> swimmer>).  %1.00;0.90%',
             '<swan --> bird>. %0.90;0.90%',
-            'bird.'
+            10
         )
-        self.assertNotEqual(rules, None)
-
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
-
 
         self.assertTrue(
             output_contains(tasks_derived, '<swan --> swimmer>. %0.90;0.43%')
@@ -462,15 +416,11 @@ class TEST_NAL6(unittest.TestCase):
         'If Tweety can chirp, then it is a bird.
         ''outputMustContain('<<{Tweety} --> [chirping]> ==> <{Tweety} --> bird>>. %1.00;0.81%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<(&&,<$x --> [chirping]>,<$x --> [with_wings]>) ==> <$x --> bird>>. %1.00;0.90%',
             '<{Tweety} --> [with_wings]>.  %1.00;0.90%',
-            '[with_wings].'
+            30
         )
-        self.assertNotEqual(rules, None)
-
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
-
 
         self.assertTrue(
             output_contains(tasks_derived, '<<{Tweety} --> [chirping]> ==> <{Tweety} --> bird>>. %1.00;0.81%')
@@ -493,15 +443,11 @@ class TEST_NAL6(unittest.TestCase):
         'If Tweety can chirp and eats worms, then it is a bird.
         ''outputMustContain('<(&&,<(*,{Tweety},worms) --> food>,<{Tweety} --> [chirping]>) ==> <{Tweety} --> bird>>. %1.00;0.81%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<(&&,<$x --> flyer>,<$x --> [chirping]>, <(*, $x, worms) --> food>) ==> <$x --> bird>>.%1.00;0.90%',
             '<{Tweety} --> flyer>.  %1.00;0.90%',
-            'flyer.'
+            10
         )
-        self.assertNotEqual(rules, None)
-
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
-
 
         self.assertTrue(
             output_contains(tasks_derived, '<(&&,<(*,{Tweety},worms) --> food>,<{Tweety} --> [chirping]>) ==> <{Tweety} --> bird>>. %1.00;0.81%')
@@ -524,18 +470,14 @@ class TEST_NAL6(unittest.TestCase):
         'Lock-1 can be opened by every key.
         ''outputMustContain('<<$1 --> key> ==> <{lock1} --> (/,open,$1,_)>>. %1.00;0.81%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<(&&,<$x --> key>,<$y --> lock>) ==> <$y --> (/,open,$x,_)>>. %1.00;0.90%',
             '<{lock1} --> lock>. %1.00;0.90%',
-            'lock.'
+            20
         )
-        self.assertNotEqual(rules, None)
-
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
-
 
         self.assertTrue(
-            output_contains(tasks_derived, '<<$1 --> key> ==> <{lock1} --> (/,open,$1,_)>>. %1.00;0.81%')
+            output_contains(tasks_derived, '<<$0 --> key> ==> <{lock1} --> (/,open,$0,_)>>. %1.00;0.81%')
         )
         pass
 
@@ -555,17 +497,14 @@ class TEST_NAL6(unittest.TestCase):
         'Some key can open Lock-1.
         ''outputMustContain('(&&,<#1 --> key>,<{lock1} --> (/,open,#1,_)>). %1.00;0.81%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<<$x --> lock> ==> (&&,<#y --> key>,<$x --> (/,open,#y,_)>)>. %1.00;0.90%',
             '<{lock1} --> lock>. %1.00;0.90%',
-            'lock.'
+            10
         )
-        self.assertNotEqual(rules, None)
-        
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
 
         self.assertTrue(
-            output_contains(tasks_derived, '(&&,<#1 --> key>,<{lock1} --> (/,open,#1,_)>). %1.00;0.81%')
+            output_contains(tasks_derived, '(&&,<#0 --> key>,<{lock1} --> (/,open,#0,_)>). %1.00;0.81%')
         )
 
         pass
@@ -586,17 +525,14 @@ class TEST_NAL6(unittest.TestCase):
         'I guess Lock-1 can be opened by every key.
         ''outputMustContain('<<$1 --> key> ==> <{lock1} --> (/,open,$1,_)>>. %1.00;0.43%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '(&&,<#x --> lock>,<<$y --> key> ==> <#x --> (/,open,$y,_)>>). %1.00;0.90%',
             '<{lock1} --> lock>. %1.00;0.90%',
-            'lock.'
+            10
         )
-        self.assertNotEqual(rules, None)
-        
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
 
         self.assertTrue(
-            output_contains(tasks_derived, '<<$1 --> key> ==> <{lock1} --> (/,open,$1,_)>>. %1.00;0.43%')
+            output_contains(tasks_derived, '<<$0 --> key> ==> <{lock1} --> (/,open,$0,_)>>. %1.00;0.43%')
         )
 
         pass
@@ -617,6 +553,15 @@ class TEST_NAL6(unittest.TestCase):
         'I guess there is a key that can open Lock-1.
         ''outputMustContain('(&&,<#1 --> key>,<{lock1} --> (/,open,#1,_)>). %1.00;0.43%')
         '''
+        tasks_derived = process_two_premises(
+            '(&&,<#x --> (/,open,#y,_)>,<#x --> lock>,<#y --> key>).',
+            '<{lock1} --> lock>.',
+            10
+        )
+
+        self.assertTrue(
+            output_contains(tasks_derived, '(&&,<#0 --> key>,<{lock1} --> (/,open,#0,_)>). %1.00;0.43%')
+        )
         pass
 
 
@@ -645,27 +590,23 @@ class TEST_NAL6(unittest.TestCase):
         ''outputMustContain('(&&,<#1 --> bird>,<#1 --> swimmer>). %0.80;0.81%')
         '''
 
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<swan --> bird>. %1.00;0.90%',
             '<swan --> swimmer>. %0.80;0.90%',
-            'swan.'
+            10
         )
-        self.assertNotEqual(rules, None)
-
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
-
 
         self.assertTrue(
-            output_contains(tasks_derived, '<<$1 --> bird> ==> <$1 --> swimmer>>. %0.80;0.45%')
+            output_contains(tasks_derived, '<<$0 --> bird> ==> <$0 --> swimmer>>. %0.80;0.45%')
         )
         self.assertTrue(
-            output_contains(tasks_derived, '<<$1 --> swimmer> ==> <$1 --> bird>>. %1.00;0.39%')
+            output_contains(tasks_derived, '<<$0 --> swimmer> ==> <$0 --> bird>>. %1.00;0.39%')
         )
         self.assertTrue(
-            output_contains(tasks_derived, '<<$1 --> bird> <=> <$1 --> swimmer>>. %0.80;0.45%')
+            output_contains(tasks_derived, '<<$0 --> bird> <=> <$0 --> swimmer>>. %0.80;0.45%')
         )
         self.assertTrue(
-            output_contains(tasks_derived, '(&&,<#1 --> bird>,<#1 --> swimmer>). %0.80;0.81%')
+            output_contains(tasks_derived, '(&&,<#0 --> bird>,<#0 --> swimmer>). %0.80;0.81%')
         )
         pass
 
@@ -694,27 +635,23 @@ class TEST_NAL6(unittest.TestCase):
         'Gull and swan have some common property.
         ''outputMustContain('(&&,<gull --> #1>,<swan --> #1>). %0.80;0.81%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<gull --> swimmer>. %1.00;0.90%',
             '<swan --> swimmer>. %0.80;0.90%',
-            'swimmer.'
+            10
         )
-        self.assertNotEqual(rules, None)
-
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
-
 
         self.assertTrue(
-            output_contains(tasks_derived, '<<gull --> $1> ==> <swan --> $1>>. %0.80;0.45%')
+            output_contains(tasks_derived, '<<gull --> $0> ==> <swan --> $0>>. %0.80;0.45%')
         )
         self.assertTrue(
-            output_contains(tasks_derived, '<<swan --> $1> ==> <gull --> $1>>. %1.00;0.39%')
+            output_contains(tasks_derived, '<<swan --> $0> ==> <gull --> $0>>. %1.00;0.39%')
         )
         self.assertTrue(
-            output_contains(tasks_derived, '<<gull --> $1> <=> <swan --> $1>>. %0.80;0.45%')
+            output_contains(tasks_derived, '<<gull --> $0> <=> <swan --> $0>>. %0.80;0.45%')
         )
         self.assertTrue(
-            output_contains(tasks_derived, '(&&,<gull --> #1>,<swan --> #1>). %0.80;0.81%')
+            output_contains(tasks_derived, '(&&,<gull --> #0>,<swan --> #0>). %0.80;0.81%')
         )
         pass
 
@@ -739,21 +676,17 @@ class TEST_NAL6(unittest.TestCase):
         ''  outputMustContain('(&&,<#1 --> (/,open,_,{lock1})>,<#1 --> key>). %1.00;0.25%')
         '''
 
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<{key1} --> (/,open,_,{lock1})>. %1.00;0.90%',
             '<{key1} --> key>. %1.00;0.90%',
-            'key1.'
+            10
         )
-        self.assertNotEqual(rules, None)
-
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
-
 
         self.assertTrue(
-            output_contains(tasks_derived, '<<$1 --> key> ==> <$1 --> (/,open,_,{lock1})>>. %1.00;0.45%')
+            output_contains(tasks_derived, '<<$0 --> key> ==> <$0 --> (/,open,_,{lock1})>>. %1.00;0.45%')
         )
         self.assertTrue(
-            output_contains(tasks_derived, '(&&,<#1 --> (/,open,_,{lock1})>,<#1 --> key>). %1.00;0.81%')
+            output_contains(tasks_derived, '(&&,<#0 --> (/,open,_,{lock1})>,<#0 --> key>). %1.00;0.81%')
         )
 
         pass
@@ -777,21 +710,17 @@ class TEST_NAL6(unittest.TestCase):
         'I guess every lock can be opened by every key.
         ''outputMustContain('<(&&,<$1 --> key>,<$2 --> lock>) ==> <$2 --> (/,open,$1,_)>>. %1.00;0.45%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<<$x --> key> ==> <{lock1} --> (/,open,$x,_)>>. %1.00;0.90%',
             '<{lock1} --> lock>. %1.00;0.90%',
-            'lock1.'
+            10
         )
-        self.assertNotEqual(rules, None)
-
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
-
 
         self.assertTrue(
-            output_contains(tasks_derived, '(&&,<#1 --> lock>,<<$2 --> key> ==> <#1 --> (/,open,$2,_)>>). %1.00;0.81%')
+            output_contains(tasks_derived, '(&&,<#0 --> lock>,<<$1 --> key> ==> <#0 --> (/,open,$1,_)>>). %1.00;0.81%')
         )
         self.assertTrue(
-            output_contains(tasks_derived, '<(&&,<$1 --> key>,<$2 --> lock>) ==> <$2 --> (/,open,$1,_)>>. %1.00;0.45%')
+            output_contains(tasks_derived, '<(&&,<$0 --> key>,<$1 --> lock>) ==> <$1 --> (/,open,$0,_)>>. %1.00;0.45%')
         )
 
         pass
@@ -815,21 +744,17 @@ class TEST_NAL6(unittest.TestCase):
         'I guess every lock can be opened by some key.
         ''outputMustContain('<<$1 --> lock> ==> (&&,<#2 --> key>,<$1 --> (/,open,#2,_)>)>. %1.00;0.45%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '(&&,<#x --> key>,<{lock1} --> (/,open,#x,_)>). %1.00;0.90%',
             '<{lock1} --> lock>. %1.00;0.90%',
-            'lock1.'
+            10
         )
-        self.assertNotEqual(rules, None)
-
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
-
 
         self.assertTrue(
-            output_contains(tasks_derived, '(&&,<#1 --> key>,<#2 --> (/,open,#1,_)>,<#2 --> lock>). %1.00;0.81%')
+            output_contains(tasks_derived, '(&&,<#0 --> key>,<#1 --> (/,open,#0,_)>,<#1 --> lock>). %1.00;0.81%')
         )
         self.assertTrue(
-            output_contains(tasks_derived, '<<$1 --> lock> ==> (&&,<#2 --> key>,<$1 --> (/,open,#2,_)>)>. %1.00;0.45%')
+            output_contains(tasks_derived, '<<$0 --> lock> ==> (&&,<#1 --> key>,<$0 --> (/,open,#1,_)>)>. %1.00;0.45%')
         )
 
         pass
@@ -850,18 +775,14 @@ class TEST_NAL6(unittest.TestCase):
         'there is a lock with the property that when opened by something, this something is a key (induction)
         ''outputMustContain('<(&&,<#1 --> (/,open,$2,_)>,<#1 --> lock>) ==> <$2 --> key>>. %1.00;0.45%')    
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<<lock1 --> (/,open,$1,_)> ==> <$1 --> key>>. %1.00;0.90%',
             '<lock1 --> lock>. %1.00;0.90%',
-            'lock1.'
+            10
         )
-        self.assertNotEqual(rules, None)
-
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
-
 
         self.assertTrue(
-            output_contains(tasks_derived, '<(&&,<#1 --> (/,open,$2,_)>,<#1 --> lock>) ==> <$2 --> key>>. %1.00;0.81%')
+            output_contains(tasks_derived, '<(&&,<#0 --> (/,open,$1,_)>,<#0 --> lock>) ==> <$1 --> key>>. %1.00;0.81%')
         )
 
         pass
@@ -918,18 +839,14 @@ class TEST_NAL6(unittest.TestCase):
         ''outputMustContain('')
         //''outputMustContain('<<$1 --> lock> ==> <$1 --> (/,open,{key1},_)>>. %1.00;0.43%')       
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<<$1 --> lock> ==> (&&,<#2 --> key>,<$1 --> (/,open,#2,_)>)>. %1.00;0.90%',
             '<{key1} --> key>. %1.00;0.90% ',
-            'key.'
+            10
         )
-        self.assertNotEqual(rules, None)
-
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
-
 
         self.assertTrue(
-            output_contains(tasks_derived, '<<$1 --> lock> ==> <$1 --> (/,open,{key1},_)>>. %1.00;0.43%')
+            output_contains(tasks_derived, '<<$0 --> lock> ==> <$0 --> (/,open,{key1},_)>>. %1.00;0.43%')
         )
         pass
 
@@ -941,15 +858,11 @@ class TEST_NAL6(unittest.TestCase):
 
         ''outputMustContain('<A ==> C>. %1.00;0.43%')       
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<A ==> (&&,<#2 --> B>,C)>. %1.00;0.90%',
             '<M --> B>. %1.00;0.90%',
-            'B.'
+            10
         )
-        self.assertNotEqual(rules, None)
-
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
-
 
         self.assertTrue(
             output_contains(tasks_derived, '<A ==> C>. %1.00;0.43%')
@@ -989,18 +902,14 @@ class TEST_NAL6(unittest.TestCase):
         'whatever opens lock1 is a key
         ''outputMustContain('<<lock1 --> (/,open,$1,_)> ==> <$1 --> key>>. %1.00;0.81%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<(&&,<#1 --> lock>,<#1 --> (/,open,$2,_)>) ==> <$2 --> key>>. %1.00;0.90%',
             '<lock1 --> lock>. %1.00;0.90%',
-            'lock.'
+            10
         )
-        self.assertNotEqual(rules, None)
-
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
-
 
         self.assertTrue(
-            output_contains(tasks_derived, '<<lock1 --> (/,open,$1,_)> ==> <$1 --> key>>. %1.00;0.81%')
+            output_contains(tasks_derived, '<<lock1 --> (/,open,$0,_)> ==> <$0 --> key>>. %1.00;0.81%')
         )
         pass
 
@@ -1012,15 +921,11 @@ class TEST_NAL6(unittest.TestCase):
 
         ''outputMustContain('<<M --> B> ==> C>. %1.00;0.81%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<(&&,<#1 --> A>, <#1 --> B>) ==> C>. %1.00;0.90%',
             '<M --> A>. %1.00;0.90%',
-            'A.'
+            10
         )
-        self.assertNotEqual(rules, None)
-
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
-
 
         self.assertTrue(
             output_contains(tasks_derived, '<<M --> B> ==> C>. %1.00;0.81%')
@@ -1059,15 +964,11 @@ class TEST_NAL6(unittest.TestCase):
         'lock1 is a lock
         ''outputMustContain('<lock1 --> lock>. %1.00;0.45%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<(&&,<#1 --> lock>,<#1 --> (/,open,$2,_)>) ==> <$2 --> key>>. %1.00;0.90%',
             '<<lock1 --> (/,open,$1,_)> ==> <$1 --> key>>. %1.00;0.90%',
-            'key.'
+            10
         )
-        self.assertNotEqual(rules, None)
-
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
-
 
         self.assertTrue(
             output_contains(tasks_derived, '<lock1 --> lock>. %1.00;0.45%')
@@ -1080,15 +981,11 @@ class TEST_NAL6(unittest.TestCase):
 
         ''outputMustContain('<M --> B>. %1.00;0.45%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<(&&,<#1 --> A>,<#1 --> B>) ==> C>. %1.00;0.90%',
             '<<M --> A> ==> C>. %1.00;0.90%',
-            'A.'
+            100
         )
-        self.assertNotEqual(rules, None)
-
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
-
 
         self.assertTrue(
             output_contains(tasks_derived, '<M --> B>. %1.00;0.45%')
@@ -1208,26 +1105,21 @@ class TEST_NAL6(unittest.TestCase):
         'I guess that if something is a animal, then it is a robin. 
         ''outputMustContain('<<#1 --> D> ==> <#2 --> A>>. %1.00;0.45%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<<#x-->A> ==> (&&, <#y-->B>, <#x-->C>)>. %1.00;0.90%',
-            '<(&&, <#x-->B>, <#y-->C>) ==> <#x --> D>>. %1.00;0.90% ',
-            '(&&, <#y-->B>, <#x-->C>).', index_task=(1,), index_belief=(0,)
-        )
-        self.assertNotEqual(rules, None)
-
-        # subst_var = get_substitution__var_var(task.term, belief.term, [1], [0]) # to find possible replacement.
-        # subst_var.apply(task.term, belief.term)
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
-
-        self.assertTrue(
-            output_contains(tasks_derived, '<<#1 --> A> ==> <#2 --> D>>. %1.00;0.81%')
-        )
-        self.assertTrue(
-            output_contains(tasks_derived, '<<#1 --> D> ==> <#2 --> A>>. %1.00;0.45%')
+            '<(&&, <#x-->B>, <#y-->C>) ==> <#x --> D>>. %1.00;0.90%',
+            10
         )
 
         self.assertTrue(
-            not output_contains(tasks_derived, '<<$1 --> D> ==> <$1 --> A>>. %1.00;0.45%')
+            output_contains(tasks_derived, '<<#0 --> A> ==> <#1 --> D>>. %1.00;0.81%')
+        )
+        self.assertTrue(
+            output_contains(tasks_derived, '<<#0 --> D> ==> <#1 --> A>>. %1.00;0.45%')
+        )
+
+        self.assertTrue(
+            not output_contains(tasks_derived, '<<$0 --> D> ==> <$0 --> A>>. %1.00;0.45%')
         )
 
     def test_0(self):
@@ -1238,12 +1130,10 @@ class TEST_NAL6(unittest.TestCase):
         <(&&, <#x-->A>, <#x-->B>, <<$y-->C>==><$y-->D>>, <$z-->E>) ==> <$x-->H>>.
         '''
 
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = rule_map_two_premises(
             "<(&&, <#x-->A>, <#x-->B>, <<$y-->C>==><$y-->D>>, <$z-->E>) ==> (&&, <$z-->F>, <#p-->G>, <#p-->H>)>. %1.00;0.90%", 
             "<(&&, <$x-->F>, <#p-->G>, <#p-->H>)==><$x-->H>>. %1.00;0.90%", 
-            '(&&, <$z-->F>, <#p-->G>, <#p-->H>).', index_task=(1,), index_belief=(0,))
-        self.assertIsNotNone(rules)
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+            10)
         self.assertTrue(
             output_contains(tasks_derived, "<(&&, <#x-->A>, <#x-->B>, <<$y-->C>==><$y-->D>>, <$z-->E>) ==> <$z-->H>>. %1.00;0.81%")
         )

--- a/Tests/test_NAL/test_NAL7.py
+++ b/Tests/test_NAL/test_NAL7.py
@@ -27,14 +27,14 @@ class TEST_NAL7(unittest.TestCase):
         'If someone enter room_101, he should hold key_101 before
         ''outputMustContain('<<(*,$1,room_101) --> enter> =\> <(*,$1,key_101) --> hold>>. %0.72;0.58%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<<(*, $x, room_101) --> enter> =\> <(*, $x, door_101) --> open>>. %0.90;0.90%',
             '<<(*, $y, door_101) --> open> =\> <(*, $y, key_101) --> hold>>. %0.80;0.90%',
-            '<(*, $y, door_101) --> open>.'
+            100
         )
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+
         self.assertTrue(
-            output_contains(tasks_derived, '<<(*,$1,room_101) --> enter> =\> <(*,$1,key_101) --> hold>>. %0.72;0.58%')
+            output_contains(tasks_derived, '<<(*,$0,room_101) --> enter> =\> <(*,$0,key_101) --> hold>>. %0.72;0.58%')
         )
         pass
         
@@ -53,14 +53,13 @@ class TEST_NAL7(unittest.TestCase):
         'If someone enter room_101, he should hold key_101 before
         ''outputMustContain('<<(*,$1,key_101) --> hold> =/> <(*,$1,room_101) --> enter>>. %1.00;0.37%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<<(*, $x, room_101) --> enter> =\> <(*, $x, door_101) --> open>>. %0.90;0.90%',
             '<<(*, $y, door_101) --> open> =\> <(*, $y, key_101) --> hold>>. %0.80;0.90%',
-            '<(*, $y, door_101) --> open>.'
+            100
         )
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
         self.assertTrue(
-            output_contains(tasks_derived, '<<(*,$1,key_101) --> hold> =/> <(*,$1,room_101) --> enter>>. %1.00;0.37%')
+            output_contains(tasks_derived, '<<(*,$0,key_101) --> hold> =/> <(*,$0,room_101) --> enter>>. %1.00;0.37%')
         )
         pass
 
@@ -81,17 +80,17 @@ class TEST_NAL7(unittest.TestCase):
         'If someone enter room_101, he should hold key_101 before
         ''outputMustContain('<<(*,$1,room_101) --> enter> =\> <(*,$1,key_101) --> hold>>. %0.80;0.42%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<<(*, $x, door_101) --> open> =/> <(*, $x, room_101) --> enter>>. %0.90;0.90%',
             '<<(*, $y, door_101) --> open> =\> <(*, $y, key_101) --> hold>>. %0.80;0.90%',
-            '<(*, $y, door_101) --> open>.'
+            100
         )
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+
         self.assertTrue(
-            output_contains(tasks_derived, '<<(*,$1,key_101) --> hold> =/> <(*,$1,room_101) --> enter>>. %0.90;0.39%')
+            output_contains(tasks_derived, '<<(*,$0,key_101) --> hold> =/> <(*,$0,room_101) --> enter>>. %0.90;0.39%')
         )
         self.assertTrue(
-            output_contains(tasks_derived, '<<(*,$1,room_101) --> enter> =\> <(*,$1,key_101) --> hold>>. %0.80;0.42%')
+            output_contains(tasks_derived, '<<(*,$0,room_101) --> enter> =\> <(*,$0,key_101) --> hold>>. %0.80;0.42%')
         )
         pass
 
@@ -112,17 +111,17 @@ class TEST_NAL7(unittest.TestCase):
         'If someone enter room_101, he should hold key_101 before
         ''outputMustContain('<<(*,$1,room_101) --> enter> =\> <(*,$1,key_101) --> hold>>. %0.80;0.42%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<<(*, $y, door_101) --> open> =\> <(*, $y, key_101) --> hold>>. %0.80;0.90%',
             '<<(*, $x, door_101) --> open> =/> <(*, $x, room_101) --> enter>>. %0.90;0.90%',
-            '<(*, $y, door_101) --> open>.'
+            100
         )
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+
         self.assertTrue(
-            output_contains(tasks_derived, '<<(*,$1,key_101) --> hold> =/> <(*,$1,room_101) --> enter>>. %0.90;0.39%')
+            output_contains(tasks_derived, '<<(*,$0,key_101) --> hold> =/> <(*,$0,room_101) --> enter>>. %0.90;0.39%')
         )
         self.assertTrue(
-            output_contains(tasks_derived, '<<(*,$1,room_101) --> enter> =\> <(*,$1,key_101) --> hold>>. %0.80;0.42%')
+            output_contains(tasks_derived, '<<(*,$0,room_101) --> enter> =\> <(*,$0,key_101) --> hold>>. %0.80;0.42%')
         )
         pass
 
@@ -142,14 +141,14 @@ class TEST_NAL7(unittest.TestCase):
         'If someone hold key_101, it means he will enter room_101
         ''outputMustContain('<<(*,$1,key_101) --> hold> </> <(*,$1,room_101) --> enter>>. %0.73;0.44%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<<(*, $x, door_101) --> open> =/> <(*, $x, room_101) --> enter>>. %0.90;0.90%',
             '<<(*, $y, door_101) --> open> =\> <(*, $y, key_101) --> hold>>. %0.80;0.90%',
-            '<(*, $y, door_101) --> open>.'
+            100
         )
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+
         self.assertTrue(
-            output_contains(tasks_derived, '<<(*,$1,key_101) --> hold> </> <(*,$1,room_101) --> enter>>. %0.73;0.44%')
+            output_contains(tasks_derived, '<<(*,$0,key_101) --> hold> </> <(*,$0,room_101) --> enter>>. %0.73;0.44%')
         )
         pass
 
@@ -168,14 +167,14 @@ class TEST_NAL7(unittest.TestCase):
         'If someone hold key_101, it means he will enter room_101
         ''outputMustContain('<<(*,$1,key_101) --> hold> </> <(*,$1,room_101) --> enter>>. %0.73;0.44%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<<(*, $y, door_101) --> open> =\> <(*, $y, key_101) --> hold>>. %0.80;0.90%',
             '<<(*, $x, door_101) --> open> =/> <(*, $x, room_101) --> enter>>. %0.90;0.90%',
-            '<(*, $y, door_101) --> open>.'
+            100
         )
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+
         self.assertTrue(
-            output_contains(tasks_derived, '<<(*,$1,key_101) --> hold> </> <(*,$1,room_101) --> enter>>. %0.73;0.44%')
+            output_contains(tasks_derived, '<<(*,$0,key_101) --> hold> </> <(*,$0,room_101) --> enter>>. %0.73;0.44%')
         )
         pass
 
@@ -194,14 +193,14 @@ class TEST_NAL7(unittest.TestCase):
         'If someone hold key_101, it means he will enter room_101
         ''outputMustContain('<<(*,$1,room_101) --> enter> </> <(*,$1,key_101) --> hold>>. %0.73;0.44%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<<(*, $x, room_101) --> enter> =/> <(*, $x, door_101) --> open>>. %0.90;0.90%',
             '<<(*, $y, key_101) --> hold> =\> <(*, $y, door_101) --> open>>. %0.80;0.90%',
-            '<(*, $y, door_101) --> open>.'
+            100
         )
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+
         self.assertTrue(
-            output_contains(tasks_derived, '<<(*,$1,room_101) --> enter> </> <(*,$1,key_101) --> hold>>. %0.73;0.44%')
+            output_contains(tasks_derived, '<<(*,$0,room_101) --> enter> </> <(*,$0,key_101) --> hold>>. %0.73;0.44%')
         )
         pass
 
@@ -220,14 +219,14 @@ class TEST_NAL7(unittest.TestCase):
         'If someone hold key_101, it means he will enter room_101
         ''outputMustContain('<<(*,$1,room_101) --> enter> </> <(*,$1,key_101) --> hold>>. %0.73;0.44%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<<(*, $y, key_101) --> hold> =\> <(*, $y, door_101) --> open>>. %0.80;0.90%',
             '<<(*, $x, room_101) --> enter> =/> <(*, $x, door_101) --> open>>. %0.90;0.90%',
-            '<(*, $y, door_101) --> open>.'
+            100
         )
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+
         self.assertTrue(
-            output_contains(tasks_derived, '<<(*,$1,room_101) --> enter> </> <(*,$1,key_101) --> hold>>. %0.73;0.44%')
+            output_contains(tasks_derived, '<<(*,$0,room_101) --> enter> </> <(*,$0,key_101) --> hold>>. %0.73;0.44%')
         )
         pass
 
@@ -244,12 +243,12 @@ class TEST_NAL7(unittest.TestCase):
         ''outputMustContain('<A =/> C>. %0.80;0.42%')
         ''outputMustContain('<C =\> A>. %0.90;0.39%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<A =/> B>. %0.80;0.90%',
             '<C =\> B>. %0.90;0.90%',
-            'B.'
+            100
         )
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+
         self.assertTrue(
             output_contains(tasks_derived, '<A =/> C>. %0.80;0.42%')
         )
@@ -274,12 +273,12 @@ class TEST_NAL7(unittest.TestCase):
         'John will enter the room_101
         ''outputMustContain('<(*,John,room_101) --> enter>. :!5: %1.00;0.81%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<(*,John,key_101) --> hold>. :|: %1.00;0.90%',
             '<<(*,John,key_101) --> hold> =/> <(*,John,room_101) --> enter>>. %1.00;0.90%',
-            '<(*,John,key_101) --> hold>.'
+            20
         )
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+
         self.assertTrue(
             output_contains(tasks_derived, '<(*,John,room_101) --> enter>. :!5: %1.00;0.81%')
         )
@@ -300,12 +299,12 @@ class TEST_NAL7(unittest.TestCase):
 
         ''outputMustContain('<(*,John,key_101) --> hold>. :!-10: %1.00;0.45%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<(*,John,room_101) --> enter>. :\: %1.00;0.90%',
             '<<(*,John,key_101) --> hold> =/> <(*,John,room_101) --> enter>>. %1.00;0.90%',
-            '<(*,John,room_101) --> enter>.'
+            10
         )
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+
         self.assertTrue(
             output_contains(tasks_derived, '<(*,John,key_101) --> hold>. :!-10: %1.00;0.45%')
         )
@@ -326,12 +325,12 @@ class TEST_NAL7(unittest.TestCase):
 
         ''outputMustContain('<(*,John,key_101) --> hold>. %1.00;0.30%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<<(*,John,key_101) --> hold> =/> <(*,John,room_101) --> enter>>. %1.00;0.90%',
             '<(*,John,room_101) --> enter>. :\: %1.00;0.90%',
-            'enter.'
+            10
         )
-        tasks_derived = GeneralEngine.inference(task, belief, belief.term, task_link, term_link, rules)
+
         self.assertTrue(
             output_contains(tasks_derived, '<(*,John,key_101) --> hold>. %1.00;0.30%')
         )
@@ -365,12 +364,17 @@ class TEST_NAL7(unittest.TestCase):
 
         10
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
-            '<John --> (/,open,_,door_101)>. :|: ',
-            '<John --> (/,enter,_,room_101)>. :|: ',
-            'John.'
+        tasks_derived = process_two_premises(
+            '<John --> (/,open,_,door_101)>. :|:',
+            None,
+            6
         )
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+        tasks_derived.extend(process_two_premises(
+            '<John --> (/,enter,_,room_101)>. :|:',
+            None,
+            20
+        ))
+
         self.assertTrue(
             output_contains(tasks_derived, '<<John --> (/,enter,_,room_101)> =\> (&/,<John --> (/,open,_,door_101)>,+6)>. :!6: %1.00;0.45%')
         )
@@ -463,14 +467,14 @@ class TEST_NAL7(unittest.TestCase):
         'If someone open door_101, he will leave corridor_100
         ''outputMustContain('<<(*,$1,door_101) --> open> =/> <(*,$1,corridor_100) --> leave>>. %0.95;0.81%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<<(*, $x, door_101) --> open> =/> <(*, $x, room_101) --> enter>>. %0.95;0.90%',
             '<<(*, $x, room_101) --> enter> <|> <(*, $x, corridor_100) --> leave>>. %1.00;0.90%',
-            '<(*, $x, room_101) --> enter>.'
+            40
         )
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+
         self.assertTrue(
-            output_contains(tasks_derived, '<<(*,$1,door_101) --> open> =/> <(*,$1,corridor_100) --> leave>>. %0.95;0.81%')
+            output_contains(tasks_derived, '<<(*,$0,door_101) --> open> =/> <(*,$0,corridor_100) --> leave>>. %0.95;0.81%')
         )
         pass
 
@@ -492,10 +496,10 @@ class TEST_NAL7(unittest.TestCase):
 
         'this one is working, but throws an exception
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<(*, John, key_101) --> hold>. :\: %1.00;0.90%',
             '<(&/,<(*, John, key_101) --> hold>,+100) =/> <(*, John, room_101) --> enter>>. %1.00;0.90%',
-            'hold.'
+            200
         )
         tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
         self.assertTrue(
@@ -618,12 +622,12 @@ class TEST_NAL7(unittest.TestCase):
         ' a + 2 = c
         ''outputMustContain('<(&/,a,+2) =/> c>. %1.00;0.81%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<(&/, a, +1) =/> b>. %1.00;0.90%',
             '<(&/, b, +1) =/> c>. %1.00;0.90%',
-            'b.'
+            10
         )
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+
         self.assertTrue(
             output_contains(tasks_derived, '<(&/,a,+2) =/> c>. %1.00;0.81%')
         )
@@ -634,27 +638,25 @@ class TEST_NAL7_ANALOGY(unittest.TestCase):
         '''
         
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<A=/>B>. %1.00;0.90%',
             '<A</>C>. %1.00;0.90%',
-            'A.'
+            10
         )
-        if rules is not None:
-            tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
-            self.assertFalse(
-                output_contains(tasks_derived, '<C=/>B>. %1.00;0.81%')
-            )
+        self.assertFalse(
+            output_contains(tasks_derived, '<C=/>B>. %1.00;0.81%')
+        )
     
     def test_analogy_0_0__1(self):
         '''
         
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<A=/>B>. %1.00;0.90%',
             '<A<|>C>. %1.00;0.90%',
-            'A.'
+            10
         )
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+
         self.assertTrue(
             output_contains(tasks_derived, '<C=/>B>. %1.00;0.81%')
         )
@@ -663,12 +665,12 @@ class TEST_NAL7_ANALOGY(unittest.TestCase):
         '''
         
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<A=\>B>. %1.00;0.90%',
             '<A</>C>. %1.00;0.90%',
-            'A.'
+            10
         )
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+
         self.assertTrue(
             output_contains(tasks_derived, '<B=/>C>. %1.00;0.81%')
         )
@@ -677,12 +679,12 @@ class TEST_NAL7_ANALOGY(unittest.TestCase):
         '''
         
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<A=\>B>. %1.00;0.90%',
             '<A<|>C>. %1.00;0.90%',
-            'A.'
+            10
         )
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+
         self.assertTrue(
             output_contains(tasks_derived, '<B=/>C>. %1.00;0.81%')
         )
@@ -691,12 +693,12 @@ class TEST_NAL7_ANALOGY(unittest.TestCase):
         '''
         
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<A=|>B>. %1.00;0.90%',
             '<A</>C>. %1.00;0.90%',
-            'A.'
+            10
         )
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+
         self.assertTrue(
             output_contains(tasks_derived, '<C=\>B>. %1.00;0.81%')
         )
@@ -705,12 +707,12 @@ class TEST_NAL7_ANALOGY(unittest.TestCase):
         '''
         
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<A=|>B>. %1.00;0.90%',
             '<A<|>C>. %1.00;0.90%',
-            'A.'
+            10
         )
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+
         self.assertTrue(
             output_contains(tasks_derived, '<C=|>B>. %1.00;0.81%')
         )
@@ -733,12 +735,12 @@ class TEST_NAL7_ANALOGY(unittest.TestCase):
         '''
         
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<A=/>B>. %1.00;0.90%',
             '<C<|>A>. %1.00;0.90%',
-            'A.'
+            10
         )
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
+
         self.assertTrue(
             output_contains(tasks_derived, '<C=/>B>. %1.00;0.81%')
         )
@@ -747,27 +749,24 @@ class TEST_NAL7_ANALOGY(unittest.TestCase):
         '''
         
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<A=\>B>. %1.00;0.90%',
             '<C</>A>. %1.00;0.90%',
-            'A.'
+            10
         )
-        if rules is not None:
-            tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
-            self.assertFalse(
-                output_contains(tasks_derived, '<C=/>B>. %1.00;0.81%')
-            )
+        self.assertFalse(
+            output_contains(tasks_derived, '<C=/>B>. %1.00;0.81%')
+        )
         
     def test_analogy_0_1__3(self):
         '''
         
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<A=\>B>. %1.00;0.90%',
             '<C<|>A>. %1.00;0.90%',
-            'A.'
+            10
         )
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
         self.assertTrue(
             output_contains(tasks_derived, '<B=/>C>. %1.00;0.81%')
         )
@@ -776,12 +775,11 @@ class TEST_NAL7_ANALOGY(unittest.TestCase):
         '''
         
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<A=|>B>. %1.00;0.90%',
             '<C</>A>. %1.00;0.90%',
-            'A.'
+            10
         )
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
         self.assertTrue(
             output_contains(tasks_derived, '<C=/>B>. %1.00;0.81%')
         )
@@ -790,12 +788,11 @@ class TEST_NAL7_ANALOGY(unittest.TestCase):
         '''
         
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<A=|>B>. %1.00;0.90%',
             '<C<|>A>. %1.00;0.90%',
-            'A.'
+            10
         )
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
         self.assertTrue(
             output_contains(tasks_derived, '<C=|>B>. %1.00;0.81%')
         )
@@ -804,12 +801,11 @@ class TEST_NAL7_ANALOGY(unittest.TestCase):
         '''
         
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<A=/>B>. %1.00;0.90%',
             '<B</>C>. %1.00;0.90%',
-            'B.'
+            10
         )
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
         self.assertTrue(
             output_contains(tasks_derived, '<A=/>C>. %1.00;0.81%')
         )
@@ -818,12 +814,11 @@ class TEST_NAL7_ANALOGY(unittest.TestCase):
         '''
         
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<A=/>B>. %1.00;0.90%',
             '<B<|>C>. %1.00;0.90%',
-            'B.'
+            10
         )
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
         self.assertTrue(
             output_contains(tasks_derived, '<A=/>C>. %1.00;0.81%')
         )
@@ -832,27 +827,24 @@ class TEST_NAL7_ANALOGY(unittest.TestCase):
         '''
         
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<A=\>B>. %1.00;0.90%',
             '<B</>C>. %1.00;0.90%',
-            'B.'
+            10
         )
-        if rules is not None:
-            tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
-            self.assertFalse(
-                output_contains(tasks_derived, '<A=/>C>. %1.00;0.81%')
-            )
+        self.assertFalse(
+            output_contains(tasks_derived, '<A=/>C>. %1.00;0.81%')
+        )
     
     def test_analogy_1_0__3(self):
         '''
         
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<A=\>B>. %1.00;0.90%',
             '<B<|>C>. %1.00;0.90%',
-            'B.'
+            10
         )
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
         self.assertTrue(
             output_contains(tasks_derived, '<C=/>A>. %1.00;0.81%')
         )
@@ -861,12 +853,11 @@ class TEST_NAL7_ANALOGY(unittest.TestCase):
         '''
         
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<A=|>B>. %1.00;0.90%',
             '<B</>C>. %1.00;0.90%',
-            'B.'
+            10
         )
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
         self.assertTrue(
             output_contains(tasks_derived, '<A=/>C>. %1.00;0.81%')
         )
@@ -875,12 +866,11 @@ class TEST_NAL7_ANALOGY(unittest.TestCase):
         '''
         
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<A=|>B>. %1.00;0.90%',
             '<B<|>C>. %1.00;0.90%',
-            'B.'
+            10
         )
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
         self.assertTrue(
             output_contains(tasks_derived, '<A=|>C>. %1.00;0.81%')
         )
@@ -889,27 +879,24 @@ class TEST_NAL7_ANALOGY(unittest.TestCase):
         '''
         
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<A=/>B>. %1.00;0.90%',
             '<C</>B>. %1.00;0.90%',
-            'B.'
+            10
         )
-        if rules is not None:
-            tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
-            self.assertTrue(
-                output_contains(tasks_derived, '<A=/>C>. %1.00;0.81%')
-            )
+        self.assertTrue(
+            output_contains(tasks_derived, '<A=/>C>. %1.00;0.81%')
+        )
 
     def test_analogy_1_1__1(self):
         '''
         
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<A=/>B>. %1.00;0.90%',
             '<C<|>B>. %1.00;0.90%',
-            'B.'
+            10
         )
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
         self.assertTrue(
             output_contains(tasks_derived, '<A=/>C>. %1.00;0.81%')
         )
@@ -918,12 +905,11 @@ class TEST_NAL7_ANALOGY(unittest.TestCase):
         '''
         
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<A=\>B>. %1.00;0.90%',
             '<C</>B>. %1.00;0.90%',
-            'B.'
+            10
         )
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
         self.assertTrue(
             output_contains(tasks_derived, '<C=/>A>. %1.00;0.81%')
         )
@@ -932,12 +918,11 @@ class TEST_NAL7_ANALOGY(unittest.TestCase):
         '''
         
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<A=\>B>. %1.00;0.90%',
             '<C<|>B>. %1.00;0.90%',
-            'B.'
+            10
         )
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
         self.assertTrue(
             output_contains(tasks_derived, '<C=/>A>. %1.00;0.81%')
         )
@@ -946,12 +931,11 @@ class TEST_NAL7_ANALOGY(unittest.TestCase):
         '''
         
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<A=|>B>. %1.00;0.90%',
             '<C</>B>. %1.00;0.90%',
-            'B.'
+            10
         )
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
         self.assertTrue(
             output_contains(tasks_derived, '<A=\>C>. %1.00;0.81%')
         )
@@ -960,12 +944,11 @@ class TEST_NAL7_ANALOGY(unittest.TestCase):
         '''
         
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<A=|>B>. %1.00;0.90%',
             '<C<|>B>. %1.00;0.90%',
-            'B.'
+            10
         )
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
         self.assertTrue(
             output_contains(tasks_derived, '<A=|>C>. %1.00;0.81%')
         )

--- a/Tests/test_NAL/test_NAL8.py
+++ b/Tests/test_NAL/test_NAL8.py
@@ -29,13 +29,11 @@ class TEST_NAL8(unittest.TestCase):
         ''outputMustContain('(&/,<(*,SELF,{t002}) --> hold>,<(*,SELF,{t001}) --> at>,(^open,{t001}))! %1.00;0.81%')
         ' working in GUI but not in testcase, maybe the following string needs some escapes? but where?
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<{t001} --> [opened]>! %1.00;0.90%',
             '<(&/,<(*,SELF,{t002}) --> hold>,<(*,SELF,{t001}) --> at>,<(*,{t001}) --> ^open>) =/> <{t001} --> [opened]>>. %1.00;0.90%',
-            '<{t001} --> [opened]>.'
+            20
         )
-
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
 
         self.assertTrue(
             output_contains(tasks_derived, '(&/,<(*,SELF,{t002}) --> hold>,<(*,SELF,{t001}) --> at>,(^open,{t001}))! %1.00;0.81%')
@@ -56,13 +54,11 @@ class TEST_NAL8(unittest.TestCase):
         'The goal is to hold t002
         ''outputMustContain('<(*,SELF,{t002}) --> hold>! %1.00;0.81%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '(&/,<(*,SELF,{t002}) --> hold>,<(*,SELF,{t001}) --> at>,(^open,{t001}))! %1.00;0.90%',
-            '<(*,SELF,{t002}) --> hold>.',
-            'hold.', is_belief_term=True
+            None,
+            10
         )
-
-        tasks_derived = [rule(task, belief.term, task_link, term_link) for rule in rules] 
 
         self.assertTrue(
             output_contains(tasks_derived, '<(*,SELF,{t002}) --> hold>! %1.00;0.81%')
@@ -82,13 +78,11 @@ class TEST_NAL8(unittest.TestCase):
         'The goal for the robot is to make t002 reachable. 
         ''outputMustContain('<(*,SELF,{t002}) --> reachable>! %1.00;0.81%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '(&/,<(*,SELF,{t002}) --> reachable>,(^pick,{t002}))! %1.00;0.90%',
-            '<(*,SELF,{t002}) --> reachable>.',
-            'reachable.', is_belief_term=True
+            None,
+            10
         )
-
-        tasks_derived = [rule(task, belief.term, task_link, term_link) for rule in rules] 
 
         self.assertTrue(
             output_contains(tasks_derived, '<(*,SELF,{t002}) --> reachable>! %1.00;0.81%')
@@ -112,16 +106,14 @@ class TEST_NAL8(unittest.TestCase):
         'The goal is to make the robot at #1 and t002 is on #1 at the same time
         ''outputMustContain('(&|,<(*,SELF,#1) --> at>,<(*,{t002},#1) --> on>)! %1.00;0.81%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<(*,SELF,{t002}) --> reachable>! %1.00;0.90%',
             '<(&|,<(*,{t002},#1) --> on>,<(*,SELF,#1) --> at>)=|><(*,SELF,{t002}) --> reachable>>.',
-            'reachable.'
+            20
         )
 
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
-
         self.assertTrue(
-            output_contains(tasks_derived, '(&|,<(*,SELF,#1) --> at>,<(*,{t002},#1) --> on>)! %1.00;0.81%')
+            output_contains(tasks_derived, '(&|,<(*,SELF,#0) --> at>,<(*,{t002},#0) --> on>)! %1.00;0.81%')
         )
 
     def test_1_3_var(self):
@@ -141,16 +133,14 @@ class TEST_NAL8(unittest.TestCase):
         'The goal is to make the robot at #1 and t002 is on #1 at the same time
         ''outputMustContain('(&|,<(*,SELF,#1) --> at>,<(*,{t002},#1) --> on>)! %1.00;0.81%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<(*,SELF,{t002}) --> reachable>! %1.00;0.90%',
             '<(&|,<(*,$1,#2) --> on>,<(*,SELF,#2) --> at>)=|><(*,SELF,{t002}) --> reachable>>.',
-            'reachable.'
+            20
         )
 
-        tasks_derived = [rule(task, belief.term, task_link, term_link) for rule in rules] 
-
         self.assertTrue(
-            output_contains(tasks_derived, '(&|,<(*,SELF,#1) --> at>,<(*,{t002},#1) --> on>)!  %1.00;0.81%')
+            output_contains(tasks_derived, '(&|,<(*,SELF,#0) --> at>,<(*,{t002},#0) --> on>)!  %1.00;0.81%')
         )
 
     def test_1_4(self):
@@ -170,13 +160,11 @@ class TEST_NAL8(unittest.TestCase):
         'The goal maybe to make t003 at the robot
         ''outputMustContain('<(*,{t003},SELF) --> at>! %1.00;0.43%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '(&|,<(*,{t002},{t003}) --> on>,<(*,{t003},SELF) --> at>)!',
             '<(*,{t002},{t003}) --> on>. :|:',
-            'on.'
+            350
         )
-
-        tasks_derived = engine.inference(task, belief, belief.term, task_link, term_link, rules)
 
         self.assertTrue(
             output_contains(tasks_derived, '<(*,{t003},SELF) --> at>! %1.00;0.43%')
@@ -200,13 +188,11 @@ class TEST_NAL8(unittest.TestCase):
         'The goal maybe to make t003 at the robot
         ''outputMustContain('<(*,{t003},SELF) --> at>! %1.00;0.43%')
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<(*,{t002},{t003}) --> on>. :|:',
-            '(&|,<(*,{t002},{t003}) --> on>,<(*,{t003},SELF) --> at>)!',
-            '<(*,{t002},{t003}) --> on>.'
+            '(&|,<(*,{t002},#1) --> on>,<(*,#1,SELF) --> at>)!',
+            350
         )
-
-        tasks_derived = [rule(task, belief, task_link, term_link) for rule in rules] 
 
         self.assertTrue(
             output_contains(tasks_derived, '<(*,{t003},SELF) --> at>! %1.00;0.43%')
@@ -231,13 +217,11 @@ class TEST_NAL8(unittest.TestCase):
         ''outputMustContain('(^go_to,{t003})! %1.00;0.81%')
 
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<(*,SELF,{t003}) --> at>!',
             '<(^go_to,{t003})=/><(*,SELF,{t003}) --> at>>.',
-            'at.'
+            100
         )
-
-        tasks_derived = engine.inference(task, belief, belief.term, task_link, term_link, rules)
 
         self.assertTrue(
             output_contains(tasks_derived, '(^go_to,{t003})! %1.00;0.81%')
@@ -262,13 +246,11 @@ class TEST_NAL8(unittest.TestCase):
         ''outputMustContain('<(*,SELF,{t003}) --> at>. :!5: %1.00;0.81%')
 
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<(*,{t003}) --> ^go_to>. :|:',
             '<<(*,{t003}) --> ^go_to> =/> <(*,SELF,{t003}) --> at>>.',
-            '<(*,{t003}) --> ^go_to>.'
+            20
         )
-
-        tasks_derived = engine.inference(task, belief, belief.term, task_link, term_link, rules)
 
         self.assertTrue(
             output_contains(tasks_derived, '<(*,SELF,{t003}) --> at>. :!5: %1.00;0.81%')
@@ -292,13 +274,11 @@ class TEST_NAL8(unittest.TestCase):
         ''outputMustContain('<(*,SELF,{t003}) --> at>. :!5: %1.00;0.81%')
 
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<(*,{t003}) --> ^go_to>. :|:',
             '<<(*,$1) --> ^go_to> =/> <(*,SELF,$1) --> at>>.',
-            'at.'
+            20
         )
-
-        tasks_derived = engine.inference(task, belief, belief.term, task_link, term_link, rules)
 
         self.assertTrue(
             output_contains(tasks_derived, '<(*,SELF,{t003}) --> at>. :!5: %1.00;0.81%')
@@ -321,12 +301,11 @@ class TEST_NAL8(unittest.TestCase):
 
 
         '''
-        rules, task, concept, task_link, result1 = rule_map_task_only(
+        tasks_derived = process_two_premises(
             '<SELF --> (/,at,_,{t003})>. :\:',
-            '{t003}', (1,2)
+            None,
+            6
         )
-
-        tasks_derived = engine.inference(task, None, None, task_link, None, rules)
 
         self.assertTrue(
             output_contains(tasks_derived, '<{t003} --> (/,at,SELF,_)>. :!-5: %1.00;0.90%')
@@ -347,12 +326,11 @@ class TEST_NAL8(unittest.TestCase):
         ''outputMustContain('<{t003} --> (/,on,{t002},_)>. :!0: %1.00;0.90%')
 
         '''
-        rules, task, concept, task_link, result1 = rule_map_task_only(
+        tasks_derived = process_two_premises(
             '<(*,{t002},{t003}) --> on>. :|:',
-            '{t003}', (0,1)
+            None,
+            6
         )
-
-        tasks_derived = engine.inference(task, None, None, task_link, None, rules)
 
         self.assertTrue(
             output_contains(tasks_derived, '<{t003} --> (/,on,{t002},_)>. :!0: %1.00;0.90%')
@@ -433,13 +411,11 @@ class TEST_NAL8(unittest.TestCase):
         #     '(&|,<(*,{t002},#1) --> on>,<(*,SELF,#1) --> at>).'
         # )
 
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '(&&,A, B, D). :|:',
             '<(&&,A, B) ==> C>.',
-            'A.'
+            10
         )
-
-        tasks_derived = engine.inference(task, belief, belief.term, task_link, term_link, rules)
 
         self.assertTrue(
             output_contains(tasks_derived, '<(*,SELF,{t002}) --> reachable>. :!0: %1.00;0.81%')
@@ -495,13 +471,11 @@ class TEST_NAL8(unittest.TestCase):
 
 
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '(&/,<(*,SELF,{t002}) --> reachable>,(^pick,{t002}))! ',
             '<(*,SELF,{t002}) --> reachable>. :|: ',
-            'reachable.'
+            45
         )
-
-        tasks_derived = engine.inference(task, belief, belief.term, task_link, term_link, rules)
 
         self.assertTrue(
             output_contains(tasks_derived, '(^pick,{t002})! %1.00;0.43%')
@@ -526,13 +500,11 @@ class TEST_NAL8(unittest.TestCase):
         ''outputMustContain('<(^pick,{t002}) =/> <(*,SELF,{t002}) --> hold>>. :!0: %1.00;0.81%')
 
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '<(*,SELF,{t002}) --> reachable>. :|:',
             '<(&/,<(*,SELF,{t002}) --> reachable>,(^pick,{t002}))=/><(*,SELF,{t002}) --> hold>>.',
-            'reachable.'
+            10
         )
-
-        tasks_derived = engine.inference(task, belief, belief.term, task_link, term_link, rules)
 
         self.assertTrue(
             output_contains(tasks_derived, '<(^pick,{t002}) =/> <(*,SELF,{t002}) --> hold>>. :!0: %1.00;0.81%')
@@ -558,13 +530,11 @@ class TEST_NAL8(unittest.TestCase):
         #     output_contains(tasks_derived, '(&/, B, C). %1.00;0.43%')
         # )
 
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '(&/, A, B, C). %1.00;0.90%',
             'A. %1.00;0.90%',
-            '(&/, A, B, C).'
+            10
         )
-
-        tasks_derived = engine.inference(task, belief, belief.term, task_link, term_link, rules)
         
         self.assertTrue(
             output_contains(tasks_derived, '(&/, B, C). %1.00;0.81%')
@@ -577,13 +547,11 @@ class TEST_NAL8(unittest.TestCase):
         |- 
         (&/, A, B)!
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             'C!',
             '(&/, A, B, C).',
-            'C.'
+            10
         )
-
-        tasks_derived = engine.inference(task, belief, belief.term, task_link, term_link, rules)
         
         self.assertTrue(
             output_contains(tasks_derived, '(&/, A, B)! %1.00;0.81%')
@@ -597,14 +565,12 @@ class TEST_NAL8(unittest.TestCase):
         |- 
         (&/, B, C)!
         '''
-        rules, task, belief, concept, task_link, term_link, result1, result2 = rule_map_two_premises(
+        tasks_derived = process_two_premises(
             '(&/, A, B, C)!',
             'A.',
-            '(&/, A, B, C).'
+            10
         )
 
-        tasks_derived = engine.inference(task, belief, belief.term, task_link, term_link, rules)
-        
         self.assertTrue(
             output_contains(tasks_derived, '(&/, B, C)! %1.00;0.81%')
         )

--- a/Tests/test_NAL/test_NAL9.py
+++ b/Tests/test_NAL/test_NAL9.py
@@ -50,12 +50,11 @@ class TEST_NAL9(unittest.TestCase):
         ''outputMustContain('<cat --> animal>. :!0: %0.00;0.90%')
         '''
         
-        premise1 = '(^believe,{SELF},<cat --> animal>,FALSE)!'
-
-        nars.reset()
-        premise1: Task = Narsese.parse(premise1)
-        tasks_derived = [execute_one_premise(premise1)]
-
+        tasks_derived = process_two_premises(
+            '(^believe,{SELF},<cat --> animal>,FALSE)!',
+            None,
+            10
+        )
         self.assertTrue(
             output_contains(tasks_derived, '<cat --> animal>. :!0: %0.00;0.90%')
         )
@@ -71,11 +70,21 @@ class TEST_NAL9(unittest.TestCase):
         ''outputMustContain('<a --> b>. %1.00;0.45%')
 
         '''
-        premise1 = '(^doubt,{SELF},<a --> b>)! %1.00;0.90%'
-        
-        nars.reset()
-        premise1: Task = Narsese.parse(premise1)
-        tasks_derived = [execute_one_premise(premise1)]
+        process_two_premises(
+            '<a --> b>. %1.00;0.90%',
+            '(^doubt,{SELF},<a --> b>)! %1.00;0.90%',
+            100
+        )
+
+        tasks_derived = process_two_premises(
+            '<a --> b>?',
+            None,
+            100
+        )
+
+        self.assertTrue(
+            output_contains(tasks_derived, '<a --> b>. %1.00;0.45%')
+        )
 
 
 if __name__ == '__main__':

--- a/Tests/utils_for_test.py
+++ b/Tests/utils_for_test.py
@@ -17,6 +17,34 @@ nars = Reasoner(100, 100)
 engine: GeneralEngine = nars.inference
 
 
+def process_two_premises(premise1: str, premise2: str, n_cycle: int) -> list[Task]:
+    ''''''
+    # nars.reset() # TODO: uncomment when implemented
+    nars = Reasoner(100, 100)
+
+    tasks_all_cycles = []
+
+    success, task, task_overflow = nars.input_narsese(premise1)
+    tasks_all_cycles.append(task)
+    
+    if premise2 is not None:
+        success, task, task_overflow = nars.input_narsese(premise2)
+        tasks_all_cycles.append(task)
+
+    for tasks_all in nars.cycles(n_cycle):
+        # print('>>>', tasks_all)
+        tasks_derived, judgement_revised, goal_revised, answers_question, \
+            answers_quest, (task_operation_return, task_executed) = tasks_all
+        tasks_all_cycles.extend(tasks_derived)
+        if judgement_revised is not None:
+            tasks_all_cycles.append(judgement_revised)
+        if answers_question is not None:
+            tasks_all_cycles.extend(answers_question)
+        if answers_quest is not None:
+            tasks_all_cycles.extend(answers_quest)
+
+    return tasks_all_cycles
+
 def rule_map_two_premises(premise1: str, premise2: str, term_common: str, inverse: bool=False, is_belief_term: bool=False, index_task=None, index_belief=None) -> Tuple[List[RuleCallable], Task, Belief, Concept, TaskLink, TermLink, Tuple[Task, Task, Task, Task]]:
     ''''''
     nars.reset()

--- a/pynars/NARS/Control/Reasoner.py
+++ b/pynars/NARS/Control/Reasoner.py
@@ -46,8 +46,10 @@ class Reasoner:
         # TODO
 
     def cycles(self, n_cycle: int):
+        tasks_all_cycles = []
         for _ in range(n_cycle):
-            self.cycle()
+            tasks_all_cycles.append(self.cycle())
+        return tasks_all_cycles
 
     def input_narsese(self, text, go_cycle: bool = False) -> Tuple[bool, Union[Task, None], Union[Task, None]]:
         success, task, task_overflow = self.narsese_channel.put(text)


### PR DESCRIPTION
Some tests in NAL5, 6 & 7 still use the old format `rule_map_two_premises` and need to be fixed/updated.

This should help establish a baseline and identify areas of the code that still need improvement. A couple of bugs based on failing tests have already been created [#48 #49] with more to come.

I propose that we first merge the tests into dev and then work on fixing them one issue at a time to keep commits separated.

---
Current pass rate for **test_NAL** is **~ 67%** which is not too bad, all things considered. 142 out of 210 tests pass. 