### PR TITLE
add OpenNARS-style Distributor in Bag

### DIFF
--- a/Tests/test_Bag.py
+++ b/Tests/test_Bag.py
@@ -90,7 +90,7 @@ class TEST_Bag(unittest.TestCase):
                 cnt1 += 1
             elif task == task2: 
                 cnt2 += 1
-        self.assertGreater(cnt1, 3*cnt2)
+        self.assertGreater(cnt1, cnt2)
 
         bag.take_by_key(task1)
         bag.take_by_key(task2)

--- a/Tests/test_NAL/test_NAL2.py
+++ b/Tests/test_NAL/test_NAL2.py
@@ -84,7 +84,7 @@ class TEST_NAL2(unittest.TestCase):
         tasks_derived = process_two_premises(
             '<bird --> swimmer>. %1.00;0.90%', 
             '<{?1} --> swimmer>?', 
-            6 
+            20
         )
         self.assertTrue(
             output_contains(tasks_derived, '<{?1} --> bird>?')

--- a/Tests/test_NAL/test_NAL5.py
+++ b/Tests/test_NAL/test_NAL5.py
@@ -785,16 +785,18 @@ class TEST_NAL5(unittest.TestCase):
         tasks_derived = process_two_premises(
             '<(&&,<robin --> [flying]>,<robin --> [with_wings]>) ==> <robin --> bird>>. %1.00;0.90%', 
             '<robin --> [flying]>. %1.00;0.90%', 
-            2
+            10
         )
         self.assertTrue(
             output_contains(tasks_derived, '<<robin --> [with_wings]> ==> <robin --> bird>>. %1.00;0.81%')
         )
 
+        nars.reset()
+
         tasks_derived = process_two_premises(
             '<robin --> [flying]>. %1.00;0.90%', 
             '<(&&,<robin --> [flying]>,<robin --> [with_wings]>) ==> <robin --> bird>>. %1.00;0.90%', 
-            2
+            10
         )
         self.assertTrue(
             output_contains(tasks_derived, '<<robin --> [with_wings]> ==> <robin --> bird>>. %1.00;0.81%')

--- a/Tests/test_NAL/test_NAL6.py
+++ b/Tests/test_NAL/test_NAL6.py
@@ -750,7 +750,7 @@ class TEST_NAL6(unittest.TestCase):
         tasks_derived = process_two_premises(
             '(&&,<#x --> key>,<{lock1} --> (/,open,#x,_)>). %1.00;0.90%',
             '<{lock1} --> lock>. %1.00;0.90%',
-            10
+            20
         )
 
         self.assertTrue(
@@ -781,7 +781,7 @@ class TEST_NAL6(unittest.TestCase):
         tasks_derived = process_two_premises(
             '<<lock1 --> (/,open,$1,_)> ==> <$1 --> key>>. %1.00;0.90%',
             '<lock1 --> lock>. %1.00;0.90%',
-            10
+            20
         )
 
         self.assertTrue(
@@ -864,7 +864,7 @@ class TEST_NAL6(unittest.TestCase):
         tasks_derived = process_two_premises(
             '<A ==> (&&,<#2 --> B>,C)>. %1.00;0.90%',
             '<M --> B>. %1.00;0.90%',
-            10
+            20
         )
 
         self.assertTrue(

--- a/Tests/test_NAL/test_NAL7.py
+++ b/Tests/test_NAL/test_NAL7.py
@@ -331,7 +331,7 @@ class TEST_NAL7(unittest.TestCase):
         tasks_derived = process_two_premises(
             '<<(*,John,key_101) --> hold> =/> <(*,John,room_101) --> enter>>. %1.00;0.90%',
             '<(*,John,room_101) --> enter>. :\: %1.00;0.90%',
-            10
+            30
         )
 
         self.assertTrue(

--- a/pynars/NARS/DataStructures/_py/Bag.py
+++ b/pynars/NARS/DataStructures/_py/Bag.py
@@ -59,7 +59,7 @@ class Bag:
         
         self.levels = tuple(list() for i in range(self.n_levels))  # initialize buckets between 0 and capacity
 
-        self.currenCounter = 0
+        self.currentCounter = 0
         self.levelIndex = capacity % self.n_levels
 
         # self.buckets = self.Depq(maxlen=self.n_buckets)
@@ -74,7 +74,7 @@ class Bag:
 
     def take(self, remove = True) -> Item:
         if len(self) == 0: return None
-        if self._is_current_level_empty() or self.currenCounter == 0:
+        if self._is_current_level_empty() or self.currentCounter == 0:
             self.pointer = self.distributor.pick(self.levelIndex)
             self.levelIndex = self.distributor.next(self.levelIndex)
             while self._is_current_level_empty():
@@ -97,7 +97,7 @@ class Bag:
         else:
             item = self.levels[self.pointer][idx]
 
-        self.currenCounter = idx
+        self.currentCounter = idx
 
         return item
 

--- a/pynars/NARS/DataStructures/_py/Bag.py
+++ b/pynars/NARS/DataStructures/_py/Bag.py
@@ -59,8 +59,8 @@ class Bag:
         
         self.levels = tuple(list() for i in range(self.n_levels))  # initialize buckets between 0 and capacity
 
-        self.currentCounter = 0
-        self.levelIndex = capacity % self.n_levels
+        self.current_counter = 0
+        self.level_index = capacity % self.n_levels
 
         # self.buckets = self.Depq(maxlen=self.n_buckets)
         n_digits = int(math.log10(self.n_levels)) + 3
@@ -74,12 +74,12 @@ class Bag:
 
     def take(self, remove = True) -> Item:
         if len(self) == 0: return None
-        if self._is_current_level_empty() or self.currentCounter == 0:
-            self.pointer = self.distributor.pick(self.levelIndex)
-            self.levelIndex = self.distributor.next(self.levelIndex)
+        if self._is_current_level_empty() or self.current_counter == 0:
+            self.pointer = self.distributor.pick(self.level_index)
+            self.level_index = self.distributor.next(self.level_index)
             while self._is_current_level_empty():
-                self.pointer = self.distributor.pick(self.levelIndex)
-                self.levelIndex = self.distributor.next(self.levelIndex)
+                self.pointer = self.distributor.pick(self.level_index)
+                self.level_index = self.distributor.next(self.level_index)
 
         if self.take_in_order:
             # take the first item from the current bucket
@@ -97,7 +97,7 @@ class Bag:
         else:
             item = self.levels[self.pointer][idx]
 
-        self.currentCounter = idx
+        self.current_counter = idx
 
         return item
 

--- a/pynars/NARS/DataStructures/_py/Distributor.py
+++ b/pynars/NARS/DataStructures/_py/Distributor.py
@@ -3,7 +3,7 @@ import functools
 
 class Distributor:
     @staticmethod
-    @functools.cache
+    @functools.lru_cache(maxsize=None)
     def new(range_val):
         return Distributor(range_val)
 

--- a/pynars/NARS/DataStructures/_py/Distributor.py
+++ b/pynars/NARS/DataStructures/_py/Distributor.py
@@ -1,12 +1,18 @@
-import functools
+from functools import lru_cache
 
-
+"""
+A pseudo-random number generator, used in Bag
+"""
 class Distributor:
     @staticmethod
-    @functools.lru_cache(maxsize=None)
+    @lru_cache(maxsize=None)
     def new(range_val):
+        '''Factory method for creating new Distributors with caching to avoid repeated calculations'''
         return Distributor(range_val)
 
+    """
+    For any number N < range, there is N+1 copies of it in the array, distributed as evenly as possible
+    """
     def __init__(self, range_val):
         self.capacity = (range_val * (range_val + 1)) // 2
         self.order = [-1] * self.capacity

--- a/pynars/NARS/DataStructures/_py/Distributor.py
+++ b/pynars/NARS/DataStructures/_py/Distributor.py
@@ -1,0 +1,26 @@
+import functools
+
+
+class Distributor:
+    @staticmethod
+    @functools.cache
+    def new(range_val):
+        return Distributor(range_val)
+
+    def __init__(self, range_val):
+        self.capacity = (range_val * (range_val + 1)) // 2
+        self.order = [-1] * self.capacity
+
+        index = 0
+        for rank in range(range_val, 0, -1):
+            for time in range(rank):
+                index = ((self.capacity // rank) + index) % self.capacity
+                while self.order[index] >= 0:
+                    index = (index + 1) % self.capacity
+                self.order[index] = rank - 1
+
+    def pick(self, index):
+        return self.order[index]
+
+    def next(self, index):
+        return (index + 1) % self.capacity


### PR DESCRIPTION
See #83 

I added the distributor but looking for your suggestions to see if we can improve the implementation. The issue is that initializing the Distributor object is not exactly quick, there are multiple loops in the `__init__` method. To avoid recalculation I added a cache in the form of a static method `new` but as I am myself _new_ to python, perhaps you guys can think of better ways to optimize the calculations. With this change tests run slower but still less than 1 min.